### PR TITLE
Fix multigraph color change

### DIFF
--- a/pyzx/editor_actions.py
+++ b/pyzx/editor_actions.py
@@ -53,8 +53,7 @@ def color_change(g: BaseGraph[VT,ET], matches: List[VT]) -> rules.RewriteOutputT
     for v in matches:
         g.set_type(v, toggle_vertex(g.type(v)))
         for e in g.incident_edges(v):
-            et = g.edge_type(e)
-            g.set_edge_type(e, toggle_edge(et))
+            g.toggle_edge_type(e)
     return ({}, [],[],False)
 
 

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -872,6 +872,12 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Sets the type of the given edge."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
+    def toggle_edge_type(self, e: ET) -> None:
+        """Toggles the type of the edge between ``EdgeType.SIMPLE`` and ``EdgeType.HADAMARD``.
+        Does nothing if the edge is empty.
+        """
+        raise NotImplementedError("Not implemented on backend " + type(self).backend)
+
     def type(self, vertex: VT) -> VertexType.Type:
         """Returns the type of the given vertex:
         VertexType.BOUNDARY if it is a boundary, VertexType.Z if it is a Z node,

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -21,6 +21,7 @@ except ImportError:
 	ig = None
 
 from .base import BaseGraph, VertexType, EdgeType
+from ..utils import toggle_edge
 
 class GraphIG(BaseGraph):
 	"""Implementation of :class:`~graph.base.BaseGraph` using ``python-igraph`` 
@@ -115,6 +116,8 @@ class GraphIG(BaseGraph):
 	def set_edge_type(self, e, t):
 		self.graph.es[e]['_t'] = t
 
+	def toggle_edge_type(self, e):
+		self.set_edge_type(e, toggle_edge(self.graph.es[e]['_t']))
 
 	def type(self, v):
 		t = self.graph.vs[v]['_t']

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -19,7 +19,7 @@ from typing import Tuple, Dict, Set, Any
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label
+from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, toggle_edge
 
 class GraphS(BaseGraph[int,Tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
@@ -274,6 +274,10 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         v1,v2 = e
         self.graph[v1][v2] = t
         self.graph[v2][v1] = t
+
+    def toggle_edge_type(self, e):
+        if edge_type := self.edge_type(e):
+            self.set_edge_type(e, toggle_edge(edge_type))
 
     def type(self, vertex):
         return self.ty[vertex]

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -348,6 +348,11 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType.Type]]):
             elif t == EdgeType.HADAMARD: e.add(h=1)
             else: e.add(w_io=1)
 
+    def toggle_edge_type(self, edge):
+        v1,v2 = edge
+        e = self.graph[v1][v2]
+        e.h, e.s = e.s, e.h
+
     def type(self, vertex):
         return self.ty[vertex]
     def types(self):

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -34,6 +34,12 @@ class Edge:
         self.h = h
         self.w_io = w_io
 
+    def __repr__(self):
+        s = f"s={self.s}" if self.s else ""
+        h = f"h={self.h}" if self.h else ""
+        w_io = f"w_io={self.w_io}" if self.w_io else ""
+        return f"Edge({', '.join([s, h, w_io])})"
+
     def add(self, s: int=0, h: int=0, w_io: int=0):
         self.s += s
         self.h += h
@@ -348,9 +354,11 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType.Type]]):
             elif t == EdgeType.HADAMARD: e.add(h=1)
             else: e.add(w_io=1)
 
-    def toggle_edge_type(self, edge):
-        v1,v2 = edge
+    def toggle_edge_type(self, edge: Edge) -> None:
+        v1, v2 = edge
         e = self.graph[v1][v2]
+        if e.w_io:
+            raise ValueError(f'Cannot toggle {repr(e)}')
         e.h, e.s = e.s, e.h
 
     def type(self, vertex):

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -86,7 +86,7 @@ def toggle_edge(ty: EdgeType.Type) -> EdgeType.Type:
         return EdgeType.HADAMARD
     if ty == EdgeType.HADAMARD:
         return EdgeType.SIMPLE
-    return ty
+    raise ValueError(f'Cannot toggle {repr(ty)}')
 
 def phase_to_s(a: FractionLike, t:VertexType.Type=VertexType.Z) -> str:
     if isinstance(a, Fraction) or isinstance(a, int):

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -82,7 +82,11 @@ class EdgeType:
 
 def toggle_edge(ty: EdgeType.Type) -> EdgeType.Type:
     """Swap the regular and Hadamard edge types."""
-    return EdgeType.HADAMARD if ty == EdgeType.SIMPLE else EdgeType.SIMPLE
+    if ty == EdgeType.SIMPLE:
+        return EdgeType.HADAMARD
+    if ty == EdgeType.HADAMARD:
+        return EdgeType.SIMPLE
+    return ty
 
 def phase_to_s(a: FractionLike, t:VertexType.Type=VertexType.Z) -> str:
     if isinstance(a, Fraction) or isinstance(a, int):


### PR DESCRIPTION
The `color_change` function had been broken with the `Multigraph` implementation.

Changes:

- The implementation of `color_change` has been modified to call a new function that toggles between Hadamard and Simple edge types.

- The `toggle_edge` utility function has been changed not to do anything when the input edge type is neither Hadamard nor Simple.

- Implement `__repr__` for `multigraph.Edge` for better error messages

Related to zxcalc/zxlive#256
