### PR TITLE
return an empty generator when there are no edges between source and target

### DIFF
--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -277,6 +277,9 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
                         for _ in range(e.w_io): yield (v0, v1, EdgeType.W_IO)
         elif t != None:
             s, t = (s, t) if s < t else (t, s)
+            if t not in self.graph[s]:
+                return
+                yield
             e = self.graph[s][t]
             for _ in range(e.s): yield (s, t, EdgeType.SIMPLE)
             for _ in range(e.h): yield (s, t, EdgeType.HADAMARD)

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -279,7 +279,6 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             s, t = (s, t) if s < t else (t, s)
             if t not in self.graph[s]:
                 return
-                yield
             e = self.graph[s][t]
             for _ in range(e.s): yield (s, t, EdgeType.SIMPLE)
             for _ in range(e.h): yield (s, t, EdgeType.HADAMARD)


### PR DESCRIPTION
This fixes some keyerror exceptions