### PR TITLE
Fix tensorfy for parallel and loop edges

### DIFF
--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -85,9 +85,7 @@ def W_to_tensor(arity: int) -> np.ndarray:
     return m
 
 def pop_and_shift(verts, indices):
-    res = []
-    for v in verts:
-        res.append(indices[v].pop())
+    res = [indices[v].pop() for v in verts]
     for i in sorted(res,reverse=True):
         for w,l in indices.items():
             l2 = []
@@ -131,7 +129,7 @@ def tensorfy(g: 'BaseGraph[VT,ET]', preserve_scalar:bool=True) -> np.ndarray:
 
     for i,r in enumerate(sorted(verts_row.keys())):
         for v in sorted(verts_row[r]):
-            neigh = list(g.neighbors(v))
+            neigh = [list(set(g.edge_st(e)) - {v})[0] for e in g.incident_edges(v)]
             d = len(neigh)
             if v in inputs:
                 if types[v] != VertexType.BOUNDARY: raise ValueError("Wrong type for input:", v, types[v])

--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -169,7 +169,7 @@ def tensorfy(g: 'BaseGraph[VT,ET]', preserve_scalar:bool=True) -> np.ndarray:
                 elif g.edge_type(sl) == EdgeType.SIMPLE:
                     t = np.trace(t)
                 else:
-                    raise NotImplementedError(f"Tensor contraction for {repr(sl)} self loops are not implemented.")
+                    raise NotImplementedError(f"Tensor contraction with {repr(sl)} self-loops is not implemented.")
             nn = list(filter(lambda n: rows[n]<r or (rows[n]==r and n<v), neigh)) # TODO: allow ordering on vertex indices?
             ety = {n:g.edge_type(g.edge(v,n)) for n in nn}
             nn.sort(key=lambda n: ety[n])

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -21,10 +21,12 @@ import sys
 from types import ModuleType
 from typing import Optional
 
+
 if __name__ == '__main__':
     sys.path.append('..')
     sys.path.append('.')
 from pyzx.graph import Graph
+from pyzx.graph.multigraph import Multigraph
 from pyzx.generate import cliffords
 from pyzx.circuit import Circuit
 
@@ -131,6 +133,22 @@ class TestTensor(unittest.TestCase):
         t_adj = adjoint(t)
         circ_adj = tensorfy(circ.adjoint())
         self.assertTrue(compare_tensors(t_adj,circ_adj))
+
+    def test_multiedge_scalar(self):
+        g = Multigraph()
+        g._auto_simplify = False
+        i1 = g.add_vertex(1,0,0)
+        i2 = g.add_vertex(2,1,0)
+        g.add_edges([(i1, i2)] * 3)
+        self.assertTrue(compare_tensors(g, np.array([np.sqrt(2)**(-1)]), preserve_scalar=True))
+
+    def test_self_loop_scalar(self):
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        i1 = g.add_vertex(1,0,0)
+        g.add_edge((i1, i1))
+        self.assertTrue(compare_tensors(g, np.array([0]), preserve_scalar=True))
+
 
 
 if __name__ == '__main__':

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -21,7 +21,6 @@ import sys
 from types import ModuleType
 from typing import Optional
 
-
 if __name__ == '__main__':
     sys.path.append('..')
     sys.path.append('.')
@@ -136,7 +135,7 @@ class TestTensor(unittest.TestCase):
 
     def test_multiedge_scalar(self):
         g = Multigraph()
-        g._auto_simplify = False
+        g.set_auto_simplify(False)
         i1 = g.add_vertex(1,0,0)
         i2 = g.add_vertex(2,1,0)
         g.add_edges([(i1, i2)] * 3)
@@ -147,9 +146,33 @@ class TestTensor(unittest.TestCase):
         g.set_auto_simplify(False)
         i1 = g.add_vertex(1,0,0)
         g.add_edge((i1, i1))
+        self.assertTrue(compare_tensors(g, np.array([2]), preserve_scalar=True))
+        g.add_edge((i1, i1), 2)
         self.assertTrue(compare_tensors(g, np.array([0]), preserve_scalar=True))
 
+    def test_self_loop_state(self):
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        i0 = g.add_vertex(0,0,0)
+        i1 = g.add_vertex(2,0,1)
+        g.set_inputs((i0,))
+        g.add_edge((i0, i1))
+        self.assertTrue(compare_tensors(g, np.array([1,0])))
+        g.add_edge((i1, i1), 2)
+        self.assertTrue(compare_tensors(g, np.array([0,1])))
 
+    def test_self_loop_and_parallel_edge_map(self):
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        i0 = g.add_vertex(0,0,0)
+        i1 = g.add_vertex(2,0,1)
+        i2 = g.add_vertex(1,0,2)
+        i3 = g.add_vertex(0,0,3)
+        g.set_inputs((i0,))
+        g.set_outputs((i3,))
+        g.add_edges([(i0, i1), (i1, i1)] + [(i1, i2)] * 2)
+        g.add_edges([(i2, i2), (i2, i3)], 2)
+        self.assertTrue(compare_tensors(g, np.array([[0,0],[1,0]])))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes the `tensorify` method for Multigraphs with self-loops and parallel edges; see #245.

Tests have been added accordingly.

Also fixes zxcalc/zxlive#307.
