### PR TITLE
if there are no edges, then raise an error for edge type in multigraph

### DIFF
--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -336,6 +336,8 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
     def edge_type(self, e):
         if len(e) == 2:
             edges = list(self.edges(e[0],e[1]))
+            if len(edges) == 0:
+                raise ValueError('Edge not found')
             if len(edges) > 1:
                 # if all edges are of the same type, return that type
                 if all(e[2] == edges[0][2] for e in edges):


### PR DESCRIPTION
I think this should raise an error but for the simple graph, the current code returns 0. 
https://github.com/zxcalc/pyzx/blob/e8a0de5a2cdbf23eefecf4995ef901b1ebee1c24/pyzx/graph/graph_s.py#L272-L277
If you want, I can change it to returning 0 for multigraph as well but that seems odd to me because 0 is the same as simple type.