### PR TITLE
fix remove id for w

### DIFF
--- a/pyzx/basicrules.py
+++ b/pyzx/basicrules.py
@@ -228,6 +228,8 @@ def check_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
     return False
 
 def remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
+    if vertex_is_w(g.type(v)):
+        return remove_id_w(g, v)
     if not check_remove_id(g, v):
         return False
 
@@ -243,4 +245,21 @@ def remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
 
     return True
 
+def check_remove_id_w(g: BaseGraph[VT,ET], v: VT) -> bool:
+    w_in, w_out = get_w_io(g, v)
+    if g.vertex_degree(w_out) == 2:
+        return True
+    return False
 
+def remove_id_w(g: BaseGraph[VT,ET], v: VT) -> bool:
+    if not check_remove_id_w(g, v):
+        return False
+    w_in, w_out = get_w_io(g, v)
+    v1 = [n for n in g.neighbors(w_out) if n != w_in][0]
+    v2 = [n for n in g.neighbors(w_in) if n != w_out][0]
+    g.add_edge((v1,v2), edgetype=EdgeType.SIMPLE
+        if g.edge_type(g.edge(w_out, v1)) == g.edge_type(g.edge(w_in, v2))
+        else EdgeType.HADAMARD)
+    g.remove_vertex(w_in)
+    g.remove_vertex(w_out)
+    return True


### PR DESCRIPTION
The remove id method breaks when applied to W nodes (see https://github.com/zxcalc/zxlive/issues/349). This PR implements a special case for W nodes.
Closes https://github.com/zxcalc/zxlive/issues/349