### PR TITLE
Change draw_matplotlib function to show the figure when in shell

### DIFF
--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -159,7 +159,8 @@ def draw_matplotlib(
         figsize:Tuple[FloatInt,FloatInt]         =(8,2), 
         h_edge_draw: Literal['blue', 'box']      ='blue', 
         show_scalar: bool                        =False,
-        rows: Optional[Tuple[FloatInt,FloatInt]] =None
+        rows: Optional[Tuple[FloatInt,FloatInt]] =None,
+        show_fig                                 =False,
         ) -> Any: # TODO: Returns a matplotlib figure
 
     # lazy import matplotlib
@@ -270,9 +271,12 @@ def draw_matplotlib(
         ax.text(x-5,y,g.scalar.to_latex())
 
     ax.axis('equal')
-    plt.close()
+    if show_fig:
+        plt.show()
+    else:
+        plt.close()
     return fig1
-    #plt.show()
+    
 
 # Provides functions for displaying pyzx graphs in jupyter notebooks using d3
 

--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -159,7 +159,7 @@ def draw_matplotlib(
         figsize:Tuple[FloatInt,FloatInt]         =(8,2), 
         h_edge_draw: Literal['blue', 'box']      ='blue', 
         show_scalar: bool                        =False,
-        rows: Optional[Tuple[FloatInt,FloatInt]] =None,
+        rows: Optional[Tuple[FloatInt,FloatInt]] =None
         ) -> Any: # TODO: Returns a matplotlib figure
 
     # lazy import matplotlib

--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -160,7 +160,6 @@ def draw_matplotlib(
         h_edge_draw: Literal['blue', 'box']      ='blue', 
         show_scalar: bool                        =False,
         rows: Optional[Tuple[FloatInt,FloatInt]] =None,
-        show_fig                                 =False,
         ) -> Any: # TODO: Returns a matplotlib figure
 
     # lazy import matplotlib
@@ -271,7 +270,7 @@ def draw_matplotlib(
         ax.text(x-5,y,g.scalar.to_latex())
 
     ax.axis('equal')
-    if show_fig:
+    if get_mode() == "shell":
         plt.show()
     else:
         plt.close()


### PR DESCRIPTION
Previously, draw_matplotlib would close and return the figure by default, which worked great in jupyter notebooks, as otherwise it would end up showing the figure twice. I changed the function to detect if it is being run in the shell, in which case it shows instead of closes the figure, making running non-notebook files with drawing much easier (as described in a previous issue I raised).