### PR TITLE
Fix `Multigraph.edge` and fix `tikz_to_graph`

### DIFF
--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -320,8 +320,13 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
     #                    if v1 > v0:
     #                        yield (v0,v1)
 
-    def edge(self, s, t):
-        return (s,t) if s < t else (t,s)
+    def edge(self, s, t, et: EdgeType=EdgeType.SIMPLE):
+        s, t = (s, t) if s < t else (t, s)
+        e = self.graph[s][t]
+        if e.get_edge_count(et):
+            return (s, t, et)
+        return next(self.edges(s, t))
+
 
     def edge_set(self):
         return Counter(self.edges())

--- a/pyzx/tikz.py
+++ b/pyzx/tikz.py
@@ -367,7 +367,7 @@ def tikz_to_graph(
         src = src.replace("(","").replace(")","").strip()
         tgt = tgt.replace("(","").replace(")","").replace(";","").strip()
 
-        e = g.edge(index_dict[int(src)],index_dict[int(tgt)])
+        e = index_dict[int(src)], index_dict[int(tgt)]
 
         if style.lower() in synonyms_edge:
             if e in etab:


### PR DESCRIPTION
`Multigraph.edge` now has the same signature as `BaseGraph.edge` and does what the documentation describes.

This also fixes some simplification routines, e.g. pivot_simp.