### PR TITLE
Implement edge data storage in the graph

### DIFF
--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -248,7 +248,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns an iterable of the edge data key names."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def edata(self, edge: ET, key: str, default: Any=0) -> Any:
+    def edata(self, edge: ET, key: str, default: Any=None) -> Any:
         """Returns the data value of the given edge associated to the key.
         If this key has no value associated with it, it returns the default value."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -240,6 +240,22 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Sets the vertex data associated to key to val."""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
 
+    def clear_edata(self, edge: ET) -> None:
+        """Removes all edata associated to an edge"""
+        raise NotImplementedError("Not implemented on backend " + type(self).backend)
+
+    def edata_keys(self, edge: ET) -> Sequence[str]:
+        """Returns an iterable of the edge data key names."""
+        raise NotImplementedError("Not implemented on backend " + type(self).backend)
+
+    def edata(self, edge: ET, key: str, default: Any=0) -> Any:
+        """Returns the data value of the given edge associated to the key.
+        If this key has no value associated with it, it returns the default value."""
+        raise NotImplementedError("Not implemented on backend " + type(self).backend)
+
+    def set_edata(self, edge: ET, key: str, val: Any) -> None:
+        """Sets the edge data associated to key to val."""
+        raise NotImplementedError("Not implemented on backend " + type(self).backend)
     # }}}
 
 
@@ -559,7 +575,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         for e in other.edges():
             s,t = other.edge_st(e)
             if not s in inputs and not t in inputs:
-                self.add_edge((vtab[s],vtab[t]), edgetype=other.edge_type(e))
+                new_e = self.add_edge((vtab[s],vtab[t]), edgetype=other.edge_type(e))
+                self.set_edata_dict(new_e, other.edata_dict(e))
 
         for (no,ni,et) in plugs:
             self.add_edge((no,vtab[ni]), edgetype=et)
@@ -582,7 +599,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             vertex_map[v] = w
         for e in other.edges():
             s,t = other.edge_st(e)
-            g.add_edge((vertex_map[s],vertex_map[t]),other.edge_type(e))
+            new_e = g.add_edge((vertex_map[s],vertex_map[t]),other.edge_type(e))
+            g.set_edata_dict(new_e, other.edata_dict(e))
 
         inputs = g.inputs() + tuple(vertex_map[v] for v in other.inputs())
         outputs = g.outputs() + tuple(vertex_map[v] for v in other.outputs())
@@ -972,6 +990,16 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.clear_vdata(vertex)
         for k, v in d.items():
             self.set_vdata(vertex, k, v)
+
+    def edata_dict(self, edge: ET) -> Dict[str, Any]:
+        """Return a dict of all edge data for the given edge."""
+        return { key: self.edata(edge, key) for key in self.edata_keys(edge) }
+
+    def set_edata_dict(self, edge: ET, d: Dict[str, Any]) -> None:
+        """Set all edge data for the given edge from a dict, clearing existing data first."""
+        self.clear_edata(edge)
+        for k, v in d.items():
+            self.set_edata(edge, k, v)
 
     def is_well_formed(self) -> bool:
         """Returns whether the graph is a well-formed ZX-diagram.

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -508,7 +508,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         
         for e in self.edges():
             s, t = self.edge_st(e)
-            g.add_edge((vtab[s], vtab[t]), self.edge_type(e))
+            new_e = g.add_edge((vtab[s], vtab[t]), self.edge_type(e))
+            g.set_edata_dict(new_e, self.edata_dict(e))
 
         return g
 

--- a/pyzx/graph/graph_gt.py
+++ b/pyzx/graph/graph_gt.py
@@ -116,7 +116,7 @@ class GraphGT(BaseGraph):
 		edata = self.graph.ep.edata[edge]
 		return edata.keys() if edata else []
 
-	def edata(self, edge, key, default=0):
+	def edata(self, edge, key, default=None):
 		edata = self.graph.ep.edata[edge]
 		if edata and key in edata:
 			return edata[key]

--- a/pyzx/graph/graph_gt.py
+++ b/pyzx/graph/graph_gt.py
@@ -27,6 +27,7 @@ class GraphGT(BaseGraph):
 		self.graph = gt.Graph(directed=False)
 		self.graph.set_fast_edge_removal()
 		self.graph.vp.type = self.graph.new_vertex_property('int')
+		self.graph.ep.edata = self.graph.new_edge_property('object')
 
 	def add_vertices(self, amount):
 		self.graph.add_vertex(amount)
@@ -107,3 +108,23 @@ class GraphGT(BaseGraph):
 	def add_attribute(self, attrib_name, default=0):
 		self.graph.vertex_properties[attrib_name] = self.graph.new_vertex_property('int')
 		self.graph.vertex_properties[attrib_name].set_value(default)
+
+	def clear_edata(self, edge):
+		self.graph.ep.edata[edge] = None
+
+	def edata_keys(self, edge):
+		edata = self.graph.ep.edata[edge]
+		return edata.keys() if edata else []
+
+	def edata(self, edge, key, default=0):
+		edata = self.graph.ep.edata[edge]
+		if edata and key in edata:
+			return edata[key]
+		return default
+
+	def set_edata(self, edge, key, val):
+		edata = self.graph.ep.edata[edge]
+		if edata:
+			edata[key] = val
+		else:
+			self.graph.ep.edata[edge] = {key: val}

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -35,6 +35,7 @@ class GraphIG(BaseGraph):
 		self.graph.vs['_q'] = None
 		self.graph.vs['_r'] = None
 		self.graph.es['_t'] = None
+		self.graph.es['_edata'] = None
 		self._maxq = -1
 		self._maxr = -1
 		self.inputs = []
@@ -165,3 +166,20 @@ class GraphIG(BaseGraph):
 		except KeyError:
 			val = default
 		return val
+
+    def clear_edata(self, edge):
+        self.graph.es[edge]['_edata'] = None
+    def edata_keys(self, edge):
+        edata = self.graph.es[edge]['_edata']
+        return edata.keys() if edata else []
+    def edata(self, edge, key, default=0):
+        edata = self.graph.es[edge]['_edata']
+        if edata and key in edata:
+            return edata[key]
+        return default
+    def set_edata(self, edge, key, val):
+        edata = self.graph.es[edge]['_edata']
+        if edata:
+            edata[key] = val
+        else:
+            self.graph.es[edge]['_edata'] = {key: val}

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -172,7 +172,7 @@ class GraphIG(BaseGraph):
 	def edata_keys(self, edge):
 		edata = self.graph.es[edge]['_edata']
 		return edata.keys() if edata else []
-	def edata(self, edge, key, default=0):
+	def edata(self, edge, key, default=None):
 		edata = self.graph.es[edge]['_edata']
 		if edata and key in edata:
 			return edata[key]

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -167,19 +167,19 @@ class GraphIG(BaseGraph):
 			val = default
 		return val
 
-    def clear_edata(self, edge):
-        self.graph.es[edge]['_edata'] = None
-    def edata_keys(self, edge):
-        edata = self.graph.es[edge]['_edata']
-        return edata.keys() if edata else []
-    def edata(self, edge, key, default=0):
-        edata = self.graph.es[edge]['_edata']
-        if edata and key in edata:
-            return edata[key]
-        return default
-    def set_edata(self, edge, key, val):
-        edata = self.graph.es[edge]['_edata']
-        if edata:
-            edata[key] = val
-        else:
-            self.graph.es[edge]['_edata'] = {key: val}
+	def clear_edata(self, edge):
+		self.graph.es[edge]['_edata'] = None
+	def edata_keys(self, edge):
+		edata = self.graph.es[edge]['_edata']
+		return edata.keys() if edata else []
+	def edata(self, edge, key, default=0):
+		edata = self.graph.es[edge]['_edata']
+		if edata and key in edata:
+			return edata[key]
+		return default
+	def set_edata(self, edge, key, val):
+		edata = self.graph.es[edge]['_edata']
+		if edata:
+			edata[key] = val
+		else:
+			self.graph.es[edge]['_edata'] = {key: val}

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -359,7 +359,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         self._edata.pop(edge, None)
     def edata_keys(self, edge):
         return self._edata.get(edge, {}).keys()
-    def edata(self, edge, key, default=0):
+    def edata(self, edge, key, default=None):
         if edge in self._edata:
             return self._edata[edge].get(key, default)
         else:

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -41,9 +41,9 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         self._grounds: Set[int] = set()
 
         self._vdata: Dict[int,Any]                      = dict()
+        self._edata: Dict[Tuple[int,int],Any] = dict()
         self._inputs: Tuple[int, ...]                   = tuple()
         self._outputs: Tuple[int, ...]                  = tuple()
-        self._edata: Dict[Tuple[int,int],Any] = dict()
 
     def clone(self) -> 'GraphS':
         cpy = GraphS()
@@ -196,6 +196,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             self.nedges -= 1
             del self.graph[s][t]
             del self.graph[t][s]
+            self._edata.pop((s, t), None)
 
     def remove_edge(self, edge):
         self.remove_edges([edge])

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -43,6 +43,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         self._vdata: Dict[int,Any]                      = dict()
         self._inputs: Tuple[int, ...]                   = tuple()
         self._outputs: Tuple[int, ...]                  = tuple()
+        self._edata: Dict[Tuple[int,int],Any] = dict()
 
     def clone(self) -> 'GraphS':
         cpy = GraphS()
@@ -352,3 +353,18 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             self._vdata[vertex][key] = val
         else:
             self._vdata[vertex] = {key:val}
+
+    def clear_edata(self, edge):
+        self._edata.pop(edge, None)
+    def edata_keys(self, edge):
+        return self._edata.get(edge, {}).keys()
+    def edata(self, edge, key, default=0):
+        if edge in self._edata:
+            return self._edata[edge].get(key, default)
+        else:
+            return default
+    def set_edata(self, edge, key, val):
+        if edge in self._edata:
+            self._edata[edge][key] = val
+        else:
+            self._edata[edge] = {key: val}

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -193,6 +193,7 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
     d['inputs'] = g.inputs()
     d['outputs'] = g.outputs()
     # Convert tuple keys to strings for JSON compatibility, replacing EdgeType with its integer value
+    # This only applies to edata in Multigraph. For other classes, it returns str(k)
     def edata_key_to_str(k):
         if isinstance(k, tuple) and len(k) == 3 and hasattr(k[2], 'value'):
             return str((k[0], k[1], k[2].value))

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -197,7 +197,7 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
         if isinstance(k, tuple) and len(k) == 3 and hasattr(k[2], 'value'):
             return str((k[0], k[1], k[2].value))
         return str(k)
-    d['edata'] = {edata_key_to_str(k): v for k, v in g._edata.items()}
+    d['edata'] = {edata_key_to_str(k): v for k, v in g._edata.items()}  # type: ignore[attr-defined]
     if g.backend == 'multigraph':
         d['auto_simplify'] = g.get_auto_simplify()
 
@@ -378,7 +378,7 @@ def dict_to_graph(d: Dict[str,Any], backend: Optional[str]=None) -> BaseGraph:
                 g.set_vdata(v,k,val)
 
     if 'edata' in d:
-        g._edata = {ast.literal_eval(k): v for k, v in d['edata'].items()}
+        g._edata = {ast.literal_eval(k): v for k, v in d['edata'].items()}  # type: ignore[attr-defined]
 
     for (s,t,et) in d['edges']:
         g.add_edge((s,t),et)

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -78,6 +78,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
         self._grounds: Set[int]                         = set()
 
         self._vdata: Dict[int,Any]                      = dict()
+        self._edata: Dict[Tuple[int,int,EdgeType], Dict[str, Any]] = dict()
         self._inputs: Tuple[int, ...]                   = tuple()
         self._outputs: Tuple[int, ...]                  = tuple()
 
@@ -211,6 +212,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             if e.is_empty():
                 del self.graph[s][t]
                 del self.graph[t][s]
+                self._edata.pop((s, t, edgetype), None)
 
         return (s,t, edgetype) if s <= t else (t,s,edgetype)
 
@@ -258,6 +260,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
         if e.is_empty():
             del self.graph[s][t]
             if s != t: del self.graph[t][s]
+            self._edata.pop(edge, None)
 
         self.nedges -= 1
 
@@ -441,6 +444,29 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             self._vdata[vertex][key] = val
         else:
             self._vdata[vertex] = {key:val}
+
+    def clear_edata(self, edge):
+        self._edata.pop(edge, None)
+
+    def edata_keys(self, edge):
+        return self._edata.get(edge, {}).keys()
+
+    def edata(self, edge, key, default=0):
+        return self._edata.get(edge, {}).get(key, default)
+
+    def set_edata(self, edge, key, val):
+        if edge in self._edata:
+            self._edata[edge][key] = val
+        else:
+            self._edata[edge] = {key: val}
+
+    def edata_dict(self, edge):
+        return dict(self._edata.get(edge, {}))
+
+    def set_edata_dict(self, edge, d):
+        self.clear_edata(edge)
+        if d:
+            self._edata[edge] = dict(d)
 
     @classmethod
     def from_json(cls, js:Union[str,Dict[str,Any]]) -> 'Multigraph':

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -95,6 +95,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
         cpy._rindex = self._rindex.copy()
         cpy._maxr = self._maxr
         cpy._vdata = self._vdata.copy()
+        cpy._edata = {k: v.copy() for k, v in self._edata.items()}
         cpy.scalar = self.scalar.copy()
         cpy._inputs = tuple(list(self._inputs))
         cpy._outputs = tuple(list(self._outputs))
@@ -223,6 +224,9 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             for v1 in vs:
                 e = self.graph[v][v1]
                 self.nedges -= e.s + e.h
+                # Remove all edata for all edge types between v and v1
+                for ty in EdgeType:
+                    self._edata.pop((min(v, v1), max(v, v1), ty), None)
                 del self.graph[v][v1]
                 if v != v1: del self.graph[v1][v]
             # remove the vertex

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -455,7 +455,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
     def edata_keys(self, edge):
         return self._edata.get(edge, {}).keys()
 
-    def edata(self, edge, key, default=0):
+    def edata(self, edge, key, default=None):
         return self._edata.get(edge, {}).get(key, default)
 
     def set_edata(self, edge, key, val):


### PR DESCRIPTION
Edges can now store data similar to vertices. The immediate motivation for this was to store the curves on the edges in zxlive but this is more applications including scalable ZX, qudit ZX and other variants.