### PR TITLE
add_vertex takes index as an optional argument and subgraph_from_vertices preserves the vertex indices

### DIFF
--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -316,12 +316,17 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
                    qubit:FloatInt=-1,
                    row:FloatInt=-1,
                    phase:Optional[FractionLike]=None,
-                   ground:bool=False
+                   ground:bool=False,
+                   index: Optional[VT] = None
                    ) -> VT:
         """Add a single vertex to the graph and return its index.
         The optional parameters allow you to respectively set
         the type, qubit index, row index and phase of the vertex."""
-        v = self.add_vertices(1)[0]
+        if index is not None:
+            self.add_vertex_indexed(index)
+            v = index
+        else:
+            v = self.add_vertices(1)[0]
         self.set_type(v, ty)
         if phase is None:
             if ty == VertexType.H_BOX: phase = 1

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -663,7 +663,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         vert_map = dict()
         for v in verts:
-            w = g.add_vertex(ty[v],qs[v],rs[v],phase[v],v in grounds)
+            w = g.add_vertex(ty[v], qs[v], rs[v], phase[v], v in grounds, index=v)
             vert_map[v] = w
         for e in edges:
             s,t = self.edge_st(e)


### PR DESCRIPTION
This PR adds an optional parameter in the add_vertex method to specify the index of the vertex. The subgraph_from_vertices method will now preserve the vertex indices when returning the subgraph. This is necessary for the fix of https://github.com/zxcalc/zxlive/issues/194 implemented in the commit https://github.com/zxcalc/zxlive/commit/018e8142d0a35e1153e59b7fa51973605424e664 to work reliably. 