### PR TITLE
Allow random seeds

### DIFF
--- a/pyzx/generate.py
+++ b/pyzx/generate.py
@@ -246,10 +246,10 @@ def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int
     g.scalar.add_power(depth)
     return g
 
-def accept(p: float, rand:Optional[random.Random]=random.Random()) -> bool:
+def accept(p: float, rand:random.Random=random.Random()) -> bool:
     return p>rand.random()
 
-def random_phase(add_t: bool, rand:Optional[random.Random]=random.Random()) -> Fraction:
+def random_phase(add_t: bool, rand:random.Random=random.Random()) -> Fraction:
     if add_t:
         return Fraction(rand.randint(1,8),4)
     return Fraction(rand.randint(1,4),2)

--- a/pyzx/generate.py
+++ b/pyzx/generate.py
@@ -145,20 +145,20 @@ def CNOT_HAD_PHASE_circuit(
         A random circuit consisting of Hadamards, CNOT gates and phase gates.
 
     """
-    random.seed(seed)
+    rand = random.Random(seed)
     p_cnot = 1-p_had-p_t
     c = Circuit(qubits)
     for _ in range(depth):
-        r = random.random()
+        r = rand.random()
         if r > 1-p_had:
-            c.add_gate("HAD",random.randrange(qubits))
+            c.add_gate("HAD",rand.randrange(qubits))
         elif r > 1-p_had-p_t:
-            if not clifford: c.add_gate("T",random.randrange(qubits))
-            else: c.add_gate("S",random.randrange(qubits))
+            if not clifford: c.add_gate("T",rand.randrange(qubits))
+            else: c.add_gate("S",rand.randrange(qubits))
         else:
-            tgt = random.randrange(qubits)
+            tgt = rand.randrange(qubits)
             while True:
-                ctrl = random.randrange(qubits)
+                ctrl = rand.randrange(qubits)
                 if ctrl!=tgt: break
             c.add_gate("CNOT",tgt,ctrl)
     return c
@@ -196,10 +196,10 @@ def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int
     r += 1
 
     # random CNOTs
-    random.seed(seed)
+    rand = random.Random(seed)
     for i in range(depth):
-        c = random.randint(0, qubits-1)
-        t = random.randint(0, qubits-2)
+        c = rand.randint(0, qubits-1)
+        t = rand.randint(0, qubits-2)
         if t >= c: t += 1
         es += [(q[c], v), (q[t], v+1), (v, v+1)]
         q[c] = v
@@ -246,13 +246,13 @@ def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int
     g.scalar.add_power(depth)
     return g
 
-def accept(p: float) -> bool:
-    return p>random.random()
+def accept(p: float, rand:Optional[random.Random]=random.Random()) -> bool:
+    return p>rand.random()
 
-def random_phase(add_t: bool) -> Fraction:
+def random_phase(add_t: bool, rand:Optional[random.Random]=random.Random()) -> Fraction:
     if add_t:
-        return Fraction(random.randint(1,8),4)
-    return Fraction(random.randint(1,4),2)
+        return Fraction(rand.randint(1,8),4)
+    return Fraction(rand.randint(1,4),2)
 
 def cliffordTmeas(
         qubits: int, 
@@ -285,7 +285,7 @@ def cliffordTmeas(
     v = 0                     # next vertex to add
     r = 0                     # current row
     
-    random.seed(seed)
+    rand = random.Random(seed)
 
     num = 0.0
     rest = 1.0
@@ -331,8 +331,8 @@ def cliffordTmeas(
     r += 1
 
     for i in range(2, depth+2):
-        p = random.random()
-        q0 = random.randrange(qubits)
+        p = rand.random()
+        q0 = rand.randrange(qubits)
 
         g.add_vertex(VertexType.Z,q0,r)
         g.add_edge((qs[q0], v))
@@ -342,7 +342,7 @@ def cliffordTmeas(
 
         if p > 1 - p_cnot:
             # apply CNOT gate
-            q1 = random.randrange(qubits-1)
+            q1 = rand.randrange(qubits-1)
             if q1 >= q0: q1 += 1
 
             g.add_vertex(VertexType.X,q1,r-1)
@@ -456,29 +456,29 @@ def cliffords(
     r += 1
 
     # random gates
-    random.seed(seed)
+    rand = random.Random(seed)
     for i in range(depth):
-        c = random.randint(0, qubits-1)
-        t = random.randint(0, qubits-2)
+        c = rand.randint(0, qubits-1)
+        t = rand.randint(0, qubits-2)
         if t >= c: t += 1
-        if accept(p_two_qubit):
-            if no_hadamard or accept(p_cnot): 
+        if accept(p_two_qubit,rand):
+            if no_hadamard or accept(p_cnot,rand): 
                 es1.append((v, v+1))
                 ty += [VertexType.Z, VertexType.X]
             else: 
                 es2.append((v,v+1))
-                typ: VertexType = random.choice([VertexType.Z, VertexType.X])
+                typ: VertexType = rand.choice([VertexType.Z, VertexType.X])
                 ty += [typ, typ]
-            if accept(p_phase): phases[v] = random_phase(t_gates)
-            if accept(p_phase): phases[v+1] = random_phase(t_gates)
+            if accept(p_phase,rand): phases[v] = random_phase(t_gates,rand)
+            if accept(p_phase,rand): phases[v+1] = random_phase(t_gates,rand)
         else:
-            phases[v] = random_phase(t_gates)
-            phases[v+1] = random_phase(t_gates)
+            phases[v] = random_phase(t_gates,rand)
+            phases[v+1] = random_phase(t_gates,rand)
             ty += [VertexType.Z, VertexType.X]
         
-        if not no_hadamard and accept(p_had): es2.append((q[c],v))
+        if not no_hadamard and accept(p_had,rand): es2.append((q[c],v))
         else: es1.append((q[c],v))
-        if not no_hadamard and accept(p_had): es2.append((q[t],v+1))
+        if not no_hadamard and accept(p_had,rand): es2.append((q[t],v+1))
         else: es1.append((q[t],v+1))
 
         q[c] = v

--- a/pyzx/generate.py
+++ b/pyzx/generate.py
@@ -127,7 +127,8 @@ def CNOT_HAD_PHASE_circuit(
         depth: int,
         p_had: float = 0.2,
         p_t: float = 0.2,
-        clifford:bool=False
+        clifford:bool=False,
+        seed:Optional[int]=None
         ) -> Circuit:
     """Construct a Circuit consisting of CNOT, HAD and phase gates.
     The default phase gate is the T gate, but if ``clifford=True``\\ , then
@@ -144,6 +145,7 @@ def CNOT_HAD_PHASE_circuit(
         A random circuit consisting of Hadamards, CNOT gates and phase gates.
 
     """
+    random.seed(seed)
     p_cnot = 1-p_had-p_t
     c = Circuit(qubits)
     for _ in range(depth):
@@ -162,7 +164,7 @@ def CNOT_HAD_PHASE_circuit(
     return c
 
 
-def cnots(qubits: int, depth: int, backend:Optional[str]=None) -> BaseGraph:
+def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int]=None) -> BaseGraph:
     """Generates a circuit consisting of randomly placed CNOT gates.
     
     Args:
@@ -194,6 +196,7 @@ def cnots(qubits: int, depth: int, backend:Optional[str]=None) -> BaseGraph:
     r += 1
 
     # random CNOTs
+    random.seed(seed)
     for i in range(depth):
         c = random.randint(0, qubits-1)
         t = random.randint(0, qubits-2)
@@ -259,7 +262,8 @@ def cliffordTmeas(
         p_hsh:Optional[float]=None, 
         p_cnot:Optional[float]=None, 
         p_meas:Optional[float]=None, 
-        backend:Optional[str]=None
+        backend:Optional[str]=None,
+        seed:Optional[int]=None
         ) -> BaseGraph:
     """Generates a circuit consisting of randomly placed Clifford+T gates. Optionally, take
     probabilities of adding T, S, HSH, CNOT, and measurements.
@@ -280,6 +284,8 @@ def cliffordTmeas(
     qs = list(range(qubits))  # tracks qubit indices of vertices
     v = 0                     # next vertex to add
     r = 0                     # current row
+    
+    random.seed(seed)
 
     num = 0.0
     rest = 1.0
@@ -384,7 +390,8 @@ def cliffordT(
         p_s:Optional[float]=None,
         p_hsh:Optional[float]=None,
         p_cnot:Optional[float]=None,
-        backend:Optional[str]=None
+        backend:Optional[str]=None,
+        seed:Optional[int]=None
         ) -> BaseGraph:
     """Generates a circuit consisting of randomly placed Clifford+T gates. Optionally, take
     probabilities of adding T, S, HSH, and CNOT. If probabilities for only a subset of gates
@@ -400,14 +407,16 @@ def cliffordT(
     :param backend: When given, should be one of the possible :ref:`graph_api` backends.
     :rtype: Instance of graph of the given backend.
     """
-    return cliffordTmeas(qubits, depth, p_t, p_s, p_hsh, p_cnot, 0, backend)
+    return cliffordTmeas(qubits, depth, p_t, p_s, p_hsh, p_cnot, 0, backend, seed)
 
 def cliffords(
         qubits: int, 
         depth: int, 
         no_hadamard:bool=False,
         t_gates:bool=False,
-        backend:Optional[str]=None):
+        backend:Optional[str]=None,
+        seed:Optional[int]=None
+        ):
     """Generates a circuit consisting of randomly placed Clifford gates.
     Uses a different approach to generating Clifford circuits then :func:`cliffordT`.
 
@@ -447,6 +456,7 @@ def cliffords(
     r += 1
 
     # random gates
+    random.seed(seed)
     for i in range(depth):
         c = random.randint(0, qubits-1)
         t = random.randint(0, qubits-2)


### PR DESCRIPTION
Allow (optionally) user-specified seeds for random graph generation. This is helpful (e.g. in benchmarking datasets) as it allows one to regenerate the same graph just by specifying the same seed (provided the dimensions and other parameters are the same). This avoids having to save the graph, e.g. as json, if it will be needed again at a later date.

For instance, the graphs g and h in the following will be equivalent as they share the same seed (and the same dimensions and parameters):

```
q = 10
d = 20
g = zx.generate.cliffordT(q,d,seed=227)
h = zx.generate.cliffordT(q,d,seed=227)
zx.draw(g,scale=20)
zx.draw(h,scale=20)
```