### PR TITLE
Fix #321: Bug in tensor contraction for scalar X spiders.

### DIFF
--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -59,10 +59,11 @@ def Z_to_tensor(arity: int, phase: float) -> np.ndarray:
     return Z_box_to_tensor(arity, np.exp(1j*phase))
 
 def X_to_tensor(arity: int, phase: float) -> np.ndarray:
-    m = np.ones(2**arity, dtype = complex)
     if arity == 0:
-        m[()] = 1 + np.exp(1j*phase)
-        return m
+      m = np.zeros([2]*arity, dtype = complex)
+      m[()] = 1 + np.exp(1j*phase)
+      return m
+    m = np.ones(2**arity, dtype = complex)
     for i in range(2**arity):
         if bin(i).count("1")%2 == 0:
             m[i] += np.exp(1j*phase)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -32,7 +32,7 @@ from pyzx.circuit import Circuit
 np: Optional[ModuleType]
 try:
     import numpy as np
-    from pyzx.tensor import tensorfy, compare_tensors, compose_tensors, adjoint
+    from pyzx.tensor import tensorfy, compare_tensors, compose_tensors, adjoint, VertexType
 except ImportError:
     np = None
 
@@ -173,6 +173,14 @@ class TestTensor(unittest.TestCase):
         g.add_edges([(i0, i1), (i1, i1)] + [(i1, i2)] * 2)
         g.add_edges([(i2, i2), (i2, i3)], 2)
         self.assertTrue(compare_tensors(g, np.array([[0,0],[1,0]])))
+
+    def test_to_tensor_equivalent(self):
+        g = Graph()
+        g.add_vertex(VertexType.Z, phase=1)
+        g1 = Graph()
+        g1.add_vertex(VertexType.X, phase=1)
+        self.assertTrue(g.to_tensor() == g1.to_tensor())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Modified X_to_tensor to match Z_to_tensor and made a regression test to confirm they are equivalent now