### PR TITLE
Fix #288

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -1198,13 +1198,14 @@ class Measurement(Gate):
     target: int
     result_bit: Optional[int]
 
+    name = 'Measurement'
     quipper_name = 'measure'
     # This gate has special syntax in qasm: https://openqasm.com/language/insts.html#measurement
     # PyZX supports the following subset of the syntax:
     # * (OpenQASM 2) measure q[0] -> c[0]
     # * (OpenQASM 3) c[0] = measure q[0]
 
-    def __init__(self, target: int, result_bit: Optional[int]) -> None:
+    def __init__(self, target: int, result_bit: Optional[int] = None) -> None:
         self.target = target
         self.result_bit = result_bit
 
@@ -1212,7 +1213,7 @@ class Measurement(Gate):
         if not isinstance(other, Measurement): return False
         if self.target != other.target: return False
         if self.result_bit != other.result_bit: return False
-        return False
+        return True
 
     def reposition(self, mask, bit_mask = None):
         g = self.copy()
@@ -1227,7 +1228,7 @@ class Measurement(Gate):
             DiscardBit(self.result_bit).to_graph(g, q_mapper, c_mapper)
         # Qubit measurement
         r = q_mapper.next_row(self.target)
-        if self.result_bit is None:
+        if self.result_bit is not None:
             r = max(r, c_mapper.next_row(self.result_bit))
         v = self.graph_add_node(g,
             q_mapper,

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -124,6 +124,18 @@ class TestCircuit(unittest.TestCase):
         cz_matrix = np.array([[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,-1]])
         self.assertTrue(compare_tensors(c.to_matrix(),cz_matrix))
 
+    def test_measurement_gate(self):
+        c = Circuit(2) 
+        c1 = Circuit(2)
+        c.add_gate("Measurement", 0)
+        c1.add_gate("Measurement", 0, None)
+        
+        self.assertTrue(c.gates[0] == c1.gates[0])
+        g = c.to_graph()
+        g1 = c1.to_graph()
+        self.assertTrue(len(g.vertices()) == len(g1.vertices()))
+
+
     def test_verify_equality_permutation_option(self):
         c1 = Circuit(2)
         c2 = Circuit(2)


### PR DESCRIPTION
Initial improvements of the Measurement gate, made the result_bit optional, fixed the to_gate() functionality when result_bit = None, fixed the equality implementation