### PR TITLE
#Fix 299: handling self loops in simple graphs 

### DIFF
--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -122,6 +122,8 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     
     def add_edge(self, edge_pair, edgetype=EdgeType.SIMPLE):
         s,t = edge_pair
+        if s == t:
+            return edge_pair
         if not t in self.graph[s]:
             self.nedges += 1
             self.graph[s][t] = edgetype

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -122,15 +122,24 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     
     def add_edge(self, edge_pair, edgetype=EdgeType.SIMPLE):
         s,t = edge_pair
+        t1 = self.ty[s]
+        t2 = self.ty[t]
         if s == t:
-            return edge_pair
+            if not vertex_is_zx_like(t1) or not vertex_is_zx_like(t2):
+                raise ValueError(f'Unexpected vertex type, it should be either z or x')
+            if edgetype==EdgeType.SIMPLE:
+                return edge_pair
+            elif edgetype==EdgeType.HADAMARD:
+                self.add_to_phase(s, 1)
+                return edge_pair
+            else:
+                raise ValueError(f'The edge you are adding is not an accepted type')
+                
         if not t in self.graph[s]:
             self.nedges += 1
             self.graph[s][t] = edgetype
             self.graph[t][s] = edgetype
         else:
-            t1 = self.ty[s]
-            t2 = self.ty[t]
             if (vertex_is_zx_like(t1) and vertex_is_zx_like(t2)):
                 et1 = self.graph[s][t]
 
@@ -169,6 +178,8 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             vs = list(self.graph[v])
             # remove all edges
             for v1 in vs:
+                if v1 == v:
+                    continue
                 self.nedges -= 1
                 del self.graph[v][v1]
                 del self.graph[v1][v]
@@ -195,6 +206,8 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
 
     def remove_edges(self, edges):
         for s,t in edges:
+            if s == t:
+                continue
             self.nedges -= 1
             del self.graph[s][t]
             del self.graph[t][s]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -67,6 +67,13 @@ class TestGraphBasicMethods(unittest.TestCase):
         self.assertEqual(g.num_edges(),0)
         self.assertFalse(g.connected(v1,v2))
 
+    def test_self_loop(self):
+        g = Graph()
+        v1 = g.add_vertex()
+        g.add_edge((v1,v1))
+        self.assertEqual(g.num_edges(),0)
+        self.assertEqual(g.vertex_degree(v1), 0)
+
     def test_set_attributes(self):
         g = Graph()
         v = g.add_vertex()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -69,10 +69,29 @@ class TestGraphBasicMethods(unittest.TestCase):
 
     def test_self_loop(self):
         g = Graph()
-        v1 = g.add_vertex()
+        v1 = g.add_vertex(VertexType.X, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 0)
         g.add_edge((v1,v1))
+        g.add_edge((v2,v2))
+
         self.assertEqual(g.num_edges(),0)
         self.assertEqual(g.vertex_degree(v1), 0)
+        self.assertEqual(g.vertex_degree(v2), 0)
+        self.assertEqual(g.phases()[0], 0)
+        self.assertEqual(g.phases()[1], 0)
+
+    def test_self_loop_had_edge(self):
+        g = Graph()
+        v1 = g.add_vertex(VertexType.X, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 0)
+        g.add_edge((v1,v1), edgetype=EdgeType.HADAMARD)
+        g.add_edge((v2,v2), edgetype=EdgeType.HADAMARD)
+
+        self.assertEqual(g.num_edges(),0)
+        self.assertEqual(g.vertex_degree(v1), 0)
+        self.assertEqual(g.vertex_degree(v2), 0)
+        self.assertEqual(g.phases()[0], 1)
+        self.assertEqual(g.phases()[1], 1)
 
     def test_set_attributes(self):
         g = Graph()


### PR DESCRIPTION
Adding a self loop to a simple graph no longer causes issues, and hadamard self loops give the vertex a pi phase. Added regression tests