### PR TITLE
Replace types_dict with variable registry to fix symbolic phases

### DIFF
--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -99,6 +99,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
         self.merge_vdata: Optional[Callable[[VT,VT], None]] = None
+        self.variable_types: Dict[str,bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
         self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
     # MANDATORY OVERRIDES {{{

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 import math
+import copy
 from fractions import Fraction
 from typing import TYPE_CHECKING, Union, Optional, Generic, TypeVar, Any, Sequence
 from typing import List, Dict, Set, Tuple, Mapping, Iterable, Callable, ClassVar, Literal
@@ -23,6 +24,7 @@ from typing_extensions import Literal, GenericMeta # type: ignore # https://gith
 
 import numpy as np
 
+from ..symbolic import Poly, VarRegistry
 from ..utils import EdgeType, VertexType, toggle_edge, vertex_is_zx
 from ..utils import FloatInt, FractionLike
 from ..tensor import tensorfy, tensor_to_matrix
@@ -97,7 +99,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
         self.merge_vdata: Optional[Callable[[VT,VT], None]] = None
-        self.variable_types: Dict[str,bool] = dict() # mapping of variable names to their type (bool or continuous)
+        self.variable_types: Dict[str,bool] = dict() # mapping of variable names to their type (bool or continuous) - legacy
+        self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
     # MANDATORY OVERRIDES {{{
 
@@ -479,6 +482,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         g.track_phases = self.track_phases
         g.scalar = self.scalar.copy(conjugate=adjoint)
         g.merge_vdata = self.merge_vdata # type: ignore
+        for name in self.var_registry.vars():
+            g.var_registry.set_type(name, self.var_registry.get_type(name))
         mult:int = 1
         if adjoint:
             mult = -1
@@ -510,11 +515,14 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         else:
             g.set_inputs(new_outputs)
             g.set_outputs(new_inputs)
-        
+
         for e in self.edges():
             s, t = self.edge_st(e)
             new_e = g.add_edge((vtab[s], vtab[t]), self.edge_type(e))
             g.set_edata_dict(new_e, self.edata_dict(e))
+
+        # Rebind all variables in phases to the new graph's registry
+        g.rebind_variables_to_registry()
 
         return g
 
@@ -1031,16 +1039,38 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
     def get_auto_simplify(self) -> bool:
         """Returns whether this graph auto-simplifies parallel edges
-        
+
         For multigraphs, this parameter might change, but simple graphs should always return True."""
         return True
 
+    def rebind_variables_to_registry(self) -> None:
+        """Rebind all variables in phases to this graph's registry.
+        This should be called after deep copying a graph to ensure all variables
+        reference the new graph's registry."""
+        for v in self.vertices():
+            phase = self.phase(v)
+            if isinstance(phase, Poly):
+                phase.rebind_variables_to_registry(self.var_registry)
+
+    def __deepcopy__(self, memo):
+        """Custom deepcopy implementation to ensure variable registry is properly handled
+        while using Python's default deepcopy behavior."""
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        # Copy all attributes using default deepcopy
+        for k, v in self.__dict__.items():
+            setattr(result, k, copy.deepcopy(v, memo))
+        # Rebind all variables to the new registry
+        result.rebind_variables_to_registry()
+        return result
+
     def set_auto_simplify(self, s: bool) -> None:
         """Set whether this graph auto-simplifies parallel edges
-        
+
         Simple graphs should always auto-simplify, so this method is a no-op."""
         pass
-    
+
     def is_phase_gadget(self, v: VT) -> bool:
         """Returns True if the vertex is the 'hub' of a phase gadget"""
         if not vertex_is_zx(self.type(v)) or self.phase(v) != 0 or self.vertex_degree(v) < 2:

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -99,7 +99,6 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
         self.merge_vdata: Optional[Callable[[VT,VT], None]] = None
-        self.variable_types: Dict[str,bool] = dict() # mapping of variable names to their type (bool or continuous) - legacy
         self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
     # MANDATORY OVERRIDES {{{

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -57,9 +57,7 @@ def string_to_phase(string: str, g: Union[BaseGraph,'GraphDiff']) -> Union[Fract
             return Fraction(int(s))
     except ValueError:
         def _new_var(name: str) -> Poly:
-            if name not in g.variable_types:
-                g.variable_types[name] = False
-            return new_var(name, g.variable_types)
+            return new_var(name, is_bool=g.var_registry.get_type(name, False), registry=g.var_registry)
         try:
             return parse(string, _new_var)
         except Exception as e:

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -29,7 +29,7 @@ from .graph import Graph
 from .scalar import Scalar
 from .base import BaseGraph, VT, ET
 from ..simplify import id_simp
-from ..symbolic import parse, Poly, new_var
+from ..symbolic import parse, Poly, new_var, VarRegistry
 if TYPE_CHECKING:
     from .diff import GraphDiff
     from .multigraph import Multigraph
@@ -182,7 +182,7 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
     d = {
         "version": 2,
         "backend": g.backend,
-        "variable_types": g.variable_types, # Potential source of error: this dictionary is mutable
+        "variable_types": g.var_registry.types, # Potential source of error: this dictionary is mutable
     }
     if hasattr(g,'name'):
         d['name'] = g.name
@@ -353,9 +353,9 @@ def dict_to_graph(d: Dict[str,Any], backend: Optional[str]=None) -> BaseGraph:
     if backend == None:
         backend = d.get('backend', None)
         if backend is None: raise ValueError("No backend specified in dictionary")
-    
+
     g = Graph(backend)
-    g.variable_types = d.get('variable_types',{})
+    g.var_registry = VarRegistry(d.get('variable_types',{}))
     if g.backend == 'multigraph':
         if TYPE_CHECKING:
             assert isinstance(g, Multigraph)

--- a/pyzx/symbolic.py
+++ b/pyzx/symbolic.py
@@ -30,8 +30,11 @@ from fractions import Fraction
 
 class VarRegistry:
     """Registry to track variable types for a specific graph"""
-    def __init__(self):
-        self.types = {}  # name -> is_bool
+
+    types: Dict[str, bool]  # name -> is_bool
+
+    def __init__(self, types: Optional[Dict[str, bool]] = None):
+        self.types = types if types is not None else {}
 
     def get_type(self, name: str, default: bool = False) -> bool:
         """Get the type of a variable, using default if not found"""


### PR DESCRIPTION
## Problem
  The PyZX library previously used a `types_dict` approach for managing symbolic variable types (boolean vs. continuous), which had several critical issues:

1. **Consistency problems**: Different polynomials containing variables with the same name could have inconsistent types
2. **Deep copy issues**: Variable type information was lost when graphs were deep copied
3. **Reference problems**: Type changes wouldn't propagate to all instances of a variable
4. Symbolic phases broken in **ZXLive**: see issues https://github.com/zxcalc/zxlive/issues/385 , https://github.com/zxcalc/zxlive/issues/332 , https://github.com/zxcalc/zxlive/issues/366

## Solution
This PR replaces the `types_dict` approach with a registry-based pattern that:

1. Associates variables with graphs: Each graph has its own `VarRegistry` to track variable types
2. Maintains name-based identity: Variables with the same name in the same graph always share the same type
3. Preserves types during copying: Deep copied graphs have their variables properly rebound to the new registry
5. Simplifies API: No more need for `freeze()` calls to fix variable types

## Key Changes
* Added `VarRegistry` class to manage variable types centrally per graph
* Modified `Var` class to work with a registry instead of local type storage
* Added `rebind_variables_to_registry()` method to ensure variables are properly bound after copying
* Implemented custom `__deepcopy__` for `BaseGraph` to preserve registry references
* Updated serialization in `GraphDiff` to work with the new registry

## Benefits
* More reliable variable type tracking across complex graph operations
* Correct behavior when deep copying graphs
* Simpler, more intuitive API for working with symbolic variables
* Better consistency between variable instances