### PR TITLE
Make the Scalar class compatible with symbolic phases

### DIFF
--- a/pyzx/editor_actions.py
+++ b/pyzx/editor_actions.py
@@ -21,7 +21,7 @@ from fractions import Fraction
 
 from typing import Callable, Optional, List, Dict, Tuple
 
-from .utils import EdgeType, VertexType, FractionLike
+from .utils import EdgeType, VertexType, FractionLike, phase_is_pauli
 from .utils import toggle_edge, vertex_is_zx, toggle_vertex
 from .graph.base import BaseGraph, VT, ET, upair
 import pyzx.rewrite_rules.rules as rules
@@ -67,8 +67,12 @@ def pauli_matcher(
     phases = g.phases()
     types = g.types()
     m: List[Tuple[VT,VT]] = []
-    paulis = {v for v in candidates
-                if phases[v] == 1 and vertex_is_zx(types[v])}
+    paulis: set = set()
+    for v in candidates:
+        if not vertex_is_zx(types[v]): continue
+        if isinstance(phases[v], (int, Fraction)) and phases[v] == 0: continue
+        if phase_is_pauli(phases[v]):
+            paulis.add(v)
     if not paulis: return m
     while len(candidates) > 0:
         v = candidates.pop()
@@ -112,9 +116,9 @@ def pauli_push(g: BaseGraph[VT,ET],
         new_verts = []
         if vertex_is_zx(g.type(v)):
             g.scalar.add_phase(g.phase(v))
-            g.set_phase(v,(-g.phase(v)) % 2)
+            g.set_phase(v,((1 - 2 * g.phase(w)) * g.phase(v)) % 2) # 1-2a is -1 if a=1 (i.e. pi) and 1 if a=0 (i.e. 0). We need to do it this way to handle boolean symbolic phases
             t = toggle_vertex(g.type(v))
-            p: FractionLike = Fraction(1)
+            p: FractionLike = g.phase(w)
         else:
             t = VertexType.Z
             p = 0
@@ -136,7 +140,7 @@ def pauli_push(g: BaseGraph[VT,ET],
             else:
                 r = (g.row(v) + sum(g.row(n) for n in new_verts)) / (len(new_verts) + 1)
                 q = (g.qubit(v) + sum(g.qubit(n) for n in new_verts))/(len(new_verts)+1)
-                h = g.add_vertex(VertexType.H_BOX,q,r,Fraction(1))
+                h = g.add_vertex(VertexType.H_BOX,q,r,Fraction(1)) # TODO: check if Fraction(1) is correct in case of symbolic phases
                 for n in new_verts: etab[upair(h,n)] = [1,0]
     return (etab, rem_verts, rem_edges, False)
 

--- a/pyzx/gflow.py
+++ b/pyzx/gflow.py
@@ -19,7 +19,7 @@ from typing import Dict, Set, Tuple, Optional
 
 from .linalg import Mat2
 from .graph.base import BaseGraph, VT, ET
-from .utils import vertex_is_zx
+from .utils import phase_is_clifford, phase_is_pauli, vertex_is_zx
 
 
 def gflow(
@@ -90,9 +90,9 @@ def gflow(
     if pauli:
         for v in vertices:
             p = g.phase(v) % 2
-            if p in (0,1):
+            if phase_is_pauli(p):
                 pauli_x.add(v)
-            elif p in (Fraction(1,2), Fraction(3,2)):
+            elif phase_is_clifford(p):
                 pauli_y.add(v)
 
     processed: Set[VT] = pattern_outputs.copy() | g.grounds()

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from .multigraph import Multigraph
 
 
-def string_to_phase(string: str, g: Union[BaseGraph,'GraphDiff']) -> Union[Fraction, Poly]:
+def string_to_phase(string: str, g: Optional[Union[BaseGraph,'GraphDiff']] = None) -> Union[Fraction, Poly]:
     if not string:
         return Fraction(0)
     try:
@@ -57,6 +57,8 @@ def string_to_phase(string: str, g: Union[BaseGraph,'GraphDiff']) -> Union[Fract
             return Fraction(int(s))
     except ValueError:
         def _new_var(name: str) -> Poly:
+            if g is None:
+                return new_var(name, is_bool=False)
             return new_var(name, is_bool=g.var_registry.get_type(name, False), registry=g.var_registry)
         try:
             return parse(string, _new_var)

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -292,6 +292,8 @@ class Scalar(object):
         phase -> coefficient in the sum."""
         new_sum_of_phases: Dict[FractionLike, int] = {}
         # Use the distributive law: (a*e^ip1)(b*e^ip2) = (a*b)*e^i(p1+p2)
+if not self.sum_of_phases:
+            self.sum_of_phases = {0:1}
         for phase1, coeff1 in phases.items():
             for phase2, coeff2 in self.sum_of_phases.items():
                 new_phase = phase1 + phase2

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -56,7 +56,7 @@ class Scalar(object):
         self.power2: int = 0 # Stores power of square root of two
         self.phase: FractionLike = Fraction(0) # Stores complex phase of the number
         self.phasenodes: List[FractionLike] = [] # Stores list of legless spiders, by their phases.
-        self.sum_of_phases: Dict[FractionLike, int] = {} # Maps phase -> count (coefficient in sum)
+        self.sum_of_phases: Dict[FractionLike, int] = {} # Maps phase -> coefficient in sum
         self.floatfactor: complex = 1.0
         self.is_unknown: bool = False # Whether this represents an unknown scalar value
         self.is_zero: bool = False
@@ -109,7 +109,7 @@ class Scalar(object):
         if not conjugate:
             s.sum_of_phases = copy.deepcopy(self.sum_of_phases)
         else:
-            s.sum_of_phases = {-phase: count for phase, count in self.sum_of_phases.items()}
+            s.sum_of_phases = {-phase: coeff for phase, coeff in self.sum_of_phases.items()}
         return s
 
     def conjugate(self) -> 'Scalar':
@@ -122,8 +122,8 @@ class Scalar(object):
         for node in self.phasenodes: # Node should be a Fraction
             val *= 1+cexp(node)
         sum_of_phases_val = 0j
-        for phase, count in self.sum_of_phases.items():
-            sum_of_phases_val += count * cexp(phase)
+        for phase, coeff in self.sum_of_phases.items():
+            sum_of_phases_val += coeff * cexp(phase)
         if sum_of_phases_val != 0:
             val *= sum_of_phases_val
         val *= math.sqrt(2)**self.power2
@@ -231,7 +231,7 @@ class Scalar(object):
         if self.phasenodes:
             d["phasenodes"] = [str(p) for p in self.phasenodes]
         if self.sum_of_phases:
-            d["sum_of_phases"] = {str(phase): count for phase, count in self.sum_of_phases.items()}
+            d["sum_of_phases"] = {str(phase): coeff for phase, coeff in self.sum_of_phases.items()}
         if self.is_zero:
             d["is_zero"] = self.is_zero
         if self.is_unknown:
@@ -258,7 +258,7 @@ class Scalar(object):
         if "phasenodes" in d:
             scalar.phasenodes = [Fraction(p) for p in d["phasenodes"]]
         if "sum_of_phases" in d:
-            scalar.sum_of_phases = {string_to_phase(phase): count for phase, count in d["sum_of_phases"].items()}
+            scalar.sum_of_phases = {string_to_phase(phase): coeff for phase, coeff in d["sum_of_phases"].items()}
         if "is_zero" in d:
             scalar.is_zero = bool(d["is_zero"])
         if "is_unknown" in d:
@@ -292,10 +292,10 @@ class Scalar(object):
         phase -> coefficient in the sum."""
         new_sum_of_phases: Dict[FractionLike, int] = {}
         # Use the distributive law: (a*e^ip1)(b*e^ip2) = (a*b)*e^i(p1+p2)
-        for phase1, count1 in phases.items():
-            for phase2, count2 in self.sum_of_phases.items():
+        for phase1, coeff1 in phases.items():
+            for phase2, coeff2 in self.sum_of_phases.items():
                 new_phase = phase1 + phase2
-                new_coeff = count1 * count2
+                new_coeff = coeff1 * coeff2
                 # Add the resulting term, combining with any existing term that has the same new polynomial
                 new_sum_of_phases[new_phase] = new_sum_of_phases.get(new_phase, 0) + new_coeff
         self.sum_of_phases = new_sum_of_phases

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -23,7 +23,7 @@ from fractions import Fraction
 from typing import Dict, List, Any, Union
 import json
 
-from ..utils import FloatInt, FractionLike, phase_is_pauli, phase_is_clifford
+from ..utils import FractionLike, phase_is_pauli, phase_is_clifford
 from ..symbolic import Poly
 
 __all__ = ['Scalar']
@@ -56,7 +56,7 @@ class Scalar(object):
         self.power2: int = 0 # Stores power of square root of two
         self.phase: FractionLike = Fraction(0) # Stores complex phase of the number
         self.phasenodes: List[FractionLike] = [] # Stores list of legless spiders, by their phases.
-        self.sum_of_phases: Dict[FractionLike, int] = {} # Maps phase -> coefficient in sum
+        self.sum_of_phases: Dict[FractionLike, int] = {} # Represents the term (c1*exp(i*phase1) + ... + cn*exp(i*phaseN)). The dictionary maps phase -> coefficient.
         self.floatfactor: complex = 1.0
         self.is_unknown: bool = False # Whether this represents an unknown scalar value
         self.is_zero: bool = False
@@ -245,7 +245,6 @@ class Scalar(object):
             d = json.loads(s)
         else:
             d = s
-        # print('scalar from json', repr(d))
         scalar = Scalar()
         scalar.phase = Fraction(d["phase"]) # TODO support parameters
         scalar.power2 = int(d["power2"])
@@ -267,9 +266,11 @@ class Scalar(object):
     def add_power(self, n) -> None:
         """Adds a factor of sqrt(2)^n to the scalar."""
         self.power2 += n
+
     def add_phase(self, phase: FractionLike) -> None:
         """Multiplies the scalar by a complex phase."""
         self.phase = (self.phase + phase) % 2
+
     def add_node(self, node: FractionLike) -> None:
         """A solitary spider with a phase ``node`` is converted into the
         scalar 1+e^(i*pi*node)."""
@@ -278,6 +279,7 @@ class Scalar(object):
         else:
             self.phasenodes.append(node)
         if node == 1: self.is_zero = True
+
     def add_float(self,f: complex) -> None:
         if f == 0.0:
             self.is_zero = True

--- a/pyzx/rewrite_rules/hrules.py
+++ b/pyzx/rewrite_rules/hrules.py
@@ -22,7 +22,7 @@ NEW VERSION
 from fractions import Fraction
 from itertools import combinations
 from typing import Dict, List, Tuple, Callable, Optional, Set, FrozenSet
-from pyzx.utils import EdgeType, VertexType, toggle_edge, toggle_vertex, FractionLike, FloatInt, vertex_is_zx
+from pyzx.utils import EdgeType, VertexType, toggle_edge, toggle_vertex, FractionLike, FloatInt, vertex_is_zx, phase_is_pauli
 from pyzx.simplify import *
 from pyzx.graph.base import BaseGraph, ET, VT, upair
 import pyzx.rewrite_rules.rules as rules
@@ -175,8 +175,8 @@ def match_copy(
 
     while len(candidates) > 0:
         v = candidates.pop()
-        if phases[v] not in (0,1) or types[v] == VertexType.BOUNDARY or g.vertex_degree(v) != 1:
-                    continue
+        if not phase_is_pauli(phases[v]) or types[v] == VertexType.BOUNDARY or g.vertex_degree(v) != 1:
+            continue
         w = list(g.neighbors(v))[0]
         if w in taken: continue
         tv = types[v]

--- a/pyzx/rewrite_rules/rules.py
+++ b/pyzx/rewrite_rules/rules.py
@@ -56,9 +56,11 @@ import itertools
 
 import numpy as np
 
-from pyzx.graph.multigraph import Multigraph
-
-from pyzx.utils import VertexType, EdgeType, get_w_partner, get_z_box_label, set_z_box_label, toggle_edge, vertex_is_w, vertex_is_zx, vertex_is_zx_like, FloatInt, FractionLike, get_w_io, vertex_is_z_like
+from pyzx.utils import (
+    EdgeType, FloatInt, FractionLike, VertexType, get_w_io, get_w_partner,
+    get_z_box_label, set_z_box_label, toggle_edge, vertex_is_w, vertex_is_z_like,
+    vertex_is_zx, vertex_is_zx_like, phase_is_pauli, phase_is_clifford
+)
 from pyzx.graph.base import BaseGraph, VT, ET
 from pyzx.symbolic import Poly
 
@@ -428,7 +430,7 @@ def match_pivot_parallel(
 
         v0a = phases[v0]
         v1a = phases[v1]
-        if not ((v0a in (0,1)) and (v1a in (0,1))): continue
+        if not (phase_is_pauli(v0a) and phase_is_pauli(v1a)): continue
         if g.is_ground(v0) or g.is_ground(v1):
             continue
 
@@ -499,12 +501,12 @@ def match_pivot_gadget(
         v0a = phases[v0]
         v1a = phases[v1]
 
-        if v0a not in (0,1):
-            if v1a in (0,1):
+        if not phase_is_pauli(v0a):
+            if phase_is_pauli(v1a):
                 v0, v1 = v1, v0
                 v0a, v1a = v1a, v0a
             else: continue
-        elif v1a in (0,1): continue
+        elif phase_is_pauli(v1a): continue
         # Now v0 has a Pauli phase and v1 has a non-Pauli phase
 
         if g.is_ground(v0):
@@ -567,7 +569,7 @@ def match_pivot_boundary(
     inputs = g.inputs()
     while (num == -1 or i < num) and len(candidates) > 0:
         v = candidates.pop()
-        if types[v] != VertexType.Z or phases[v] not in (0,1) or g.is_ground(v):
+        if types[v] != VertexType.Z or not phase_is_pauli(phases[v]) or g.is_ground(v):
             continue
 
         good_vert = True
@@ -595,7 +597,7 @@ def match_pivot_boundary(
                     wrong_match = True
             if len(boundaries) != 1 or wrong_match: # n is not on the boundary,
                 continue             # has too many boundaries or has neighbors of wrong type
-            if phases[n] and hasattr(phases[n], 'denominator') and phases[n].denominator == 2:
+            if not phase_is_pauli(phases[n]) and phase_is_clifford(phases[n]):
                 w = n
                 bound = boundaries[0]
             if not w:
@@ -658,7 +660,8 @@ def pivot(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -> RewriteOutp
             if not g.is_ground(v):
                 g.add_to_phase(v, 1)
 
-        if g.phase(m[0][0]) and g.phase(m[0][1]): g.scalar.add_phase(Fraction(1))
+        #if g.phase(m[0][0]) and g.phase(m[0][1]): g.scalar.add_phase(Fraction(1))
+        g.scalar.add_phase(Fraction(1) * g.phase(m[0][0]) * g.phase(m[0][1]))
         if not m[1][0] and not m[1][1]:
             g.scalar.add_power(-(k0+k1+2*k2-1))
         elif not m[1][0]:
@@ -734,7 +737,7 @@ def match_lcomp_parallel(
         va = g.phase(v)
 
         if vt != VertexType.Z: continue
-        if not (va == Fraction(1,2) or va == Fraction(3,2)): continue
+        if not phase_is_clifford(va) or phase_is_pauli(va): continue
 
         if g.is_ground(v):
             continue
@@ -761,9 +764,9 @@ def lcomp(g: BaseGraph[VT,ET], matches: List[MatchLcompType[VT]]) -> RewriteOutp
     for m in matches:
         a = g.phase(m[0])
         rem.append(m[0])
-        assert isinstance(a,Fraction)  # For mypy
-        if a.numerator == 1: g.scalar.add_phase(Fraction(1,4))
-        else: g.scalar.add_phase(Fraction(7,4))
+        #if pi/2, then scalar = pi/4
+        #if 3pi/2, then scalar = 7pi/4
+        g.scalar.add_phase(Fraction(3,2) * a - Fraction(1,2))
         n = len(m[1])
         g.scalar.add_power((n-2)*(n-1)//2)
         for i in range(n):
@@ -965,7 +968,7 @@ def match_phase_gadgets(g: BaseGraph[VT,ET],vertexf:Optional[Callable[[VT],bool]
             non_clifford = phases[v] != 0 and getattr(phases[v], 'denominator', 1) > 2
         if non_clifford and len(list(g.neighbors(v)))==1:
             n = list(g.neighbors(v))[0]
-            if phases[n] not in (0,1): continue # Not a real phase gadget (happens for scalar diagrams)
+            if not phase_is_pauli(phases[n]): continue # Not a real phase gadget (happens for scalar diagrams)
             if n in gadgets: continue # Not a real phase gadget (happens for scalar diagrams)
             if n in inputs or n in outputs: continue # Not a real phase gadget (happens for non-unitary diagrams)
             gadgets[n] = v
@@ -1027,7 +1030,7 @@ def match_supplementarity(g: BaseGraph[VT,ET], vertexf:Optional[Callable[[VT],bo
     # First we find all the non-Clifford vertices and their list of neighbors
     while len(candidates) > 0:
         v = candidates.pop()
-        if phases[v] == 0 or (not isinstance(phases[v], Poly) and phases[v].denominator <= 2): continue # Skip Clifford vertices
+        if phase_is_clifford(phases[v]): continue # Skip Clifford vertices
         neigh = set(g.neighbors(v))
         if not neigh.isdisjoint(taken): continue
         par = frozenset(neigh)
@@ -1043,7 +1046,7 @@ def match_supplementarity(g: BaseGraph[VT,ET], vertexf:Optional[Callable[[VT],bo
             if v in taken: continue
         else: parities[par] = [v]
         for w in neigh:
-            if phases[w] == 0 or (not isinstance(phases[w], Poly) and phases[w].denominator <= 2) or w in taken: continue
+            if phase_is_clifford(phases[w]) or w in taken: continue
             diff = neigh.symmetric_difference(g.neighbors(w))
             if len(diff) == 2: # Perfect overlap
                 if (phases[v] + phases[w]) % 2 == 0 or (phases[v] - phases[w]) % 2 == 1:
@@ -1106,7 +1109,7 @@ def match_copy(
 
     while len(candidates) > 0:
         v = candidates.pop()
-        if phases[v] not in (0,1) or types[v] != VertexType.Z or g.vertex_degree(v) != 1: continue
+        if not phase_is_pauli(phases[v]) or types[v] != VertexType.Z or g.vertex_degree(v) != 1: continue
         w = list(g.neighbors(v))[0]
         if types[w] != VertexType.Z: continue
         neigh = [n for n in g.neighbors(w) if n != v]

--- a/pyzx/simplify.py
+++ b/pyzx/simplify.py
@@ -279,21 +279,21 @@ class Simplifier(Generic[VT, ET]):
         p2 = self.mastergraph.phase(v2)
         m1 = self.simplifygraph.phase_mult[i1]
         m2 = self.simplifygraph.phase_mult[i2]
-        if (p2 == 0 or p2.denominator <= 2): # Deleted vertex contains Clifford phase
+        if phase_is_clifford(p2): # Deleted vertex contains Clifford phase
             if v2 in self.phantom_phases:
                 v3,i3 = self.phantom_phases[v2]
                 m2 = cast(Literal[1, -1], m2*self.simplifygraph.phase_mult[i3])
                 v2,i2 = v3,i3
                 p2 = self.mastergraph.phase(v2)
             else: return
-        if (p1 == 0 or p1.denominator <= 2): # Need to save non-Clifford location
+        if phase_is_clifford(p1): # Need to save non-Clifford location
             self.simplifygraph.phase_mult[i1] = 1
             if v1 in self.phantom_phases: # Already fused with non-Clifford before
                 v3,i3 = self.phantom_phases[v1]
                 self.mastergraph.phase_index[v3] = i1
                 del self.mastergraph.phase_index[v1]
                 p1 = self.mastergraph.phase(v3)
-                if (p1+p2).denominator <= 2:
+                if phase_is_clifford(p1 + p2):
                     del self.phantom_phases[v1]
                 v1,i1 = v3,i3
                 m1 = cast(Literal[1, -1], m1*self.simplifygraph.phase_mult[i3])
@@ -301,7 +301,7 @@ class Simplifier(Generic[VT, ET]):
                 self.phantom_phases[v1] = (v2,i2)
                 self.simplifygraph.phase_mult[i2] = m2
                 return
-        if p1.denominator <= 2 or p2.denominator <= 2: raise Exception("Clifford phases here??")
+        if phase_is_clifford(p1) or phase_is_clifford(p2): raise Exception("Clifford phases here??")
         # Both have non-Clifford phase
         if m1*m2 == 1: phase = (p1 + p2)%2
         else: phase = p1 - p2


### PR DESCRIPTION
Please merge after #354 

This PR modifies scalar.py to support symbolic phases. As such, it removes any explicit calculation of the complex scalar outside the dedicated `to_number` method. 

The main change is due to the `add_spider_pair` method. The scalar added by this method is  `1 + e^(i pi p1) + e^(i pi p2) - e^(i pi (p1+p2))` where p1 and p2 are phases of the two spiders. In the case when p1 and p2 are both non-clifford, there is no way of writing this scalar using `scalar.phase` and `scalar.phase_node`. So we introduce a new variable `scalar.sum_of_phases` which represents the term `(c1*exp(i*phase1) + ... + cn*exp(i*phaseN))` as a dictionary mapping phase->coeffecient. Rest of the changes are in support of adding the `sum_of_phases` variable.