### PR TITLE
Add regression tests for boolean Pauli axel rewrites

### DIFF
--- a/tests/test_boolean_pauli_rewrites.py
+++ b/tests/test_boolean_pauli_rewrites.py
@@ -38,6 +38,72 @@ def tensors_match(g1, g2, **subs):
 
 class TestBooleanPauliRewrites(unittest.TestCase):
 
+    def test_gadget_simp(self):
+        """`gadget_simp` must preserve the tensor for a boolean axel."""
+        g = Graph()
+        c = new_var('c', is_bool=True, registry=g.var_registry)
+        b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+        b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+        t = g.add_vertex(VertexType.Z, 0, 2)
+        n = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+        v = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+        g.add_edge((b0, t)); g.add_edge((t, b1))
+        g.add_edge((t, n), EdgeType.HADAMARD); g.add_edge((n, v), EdgeType.HADAMARD)
+        g.set_inputs((b0,)); g.set_outputs((b1,))
+
+        orig = g.copy()
+        gadget_simp(g)
+        for c_val in (0, 1):
+            self.assertTrue(tensors_match(g, orig, c=c_val),
+                            f"gadget_simp drifted at c={c_val}")
+
+    def test_teleport_reduce(self):
+        """`teleport_reduce` must commute with substitution for a boolean axel.
+
+        Two phase gadgets sharing parity {target}: boolean axel `c` and
+        constant pi axel, both with T leaves.
+        """
+        def build(c_val=None):
+            g = Graph()
+            c = (new_var('c', is_bool=True, registry=g.var_registry)
+                 if c_val is None else Fraction(c_val))
+            b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+            b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+            t = g.add_vertex(VertexType.Z, 0, 2)
+            n1 = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+            v1 = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+            n2 = g.add_vertex(VertexType.Z, -1, 2, phase=Fraction(1))
+            v2 = g.add_vertex(VertexType.Z, -2, 2, phase=Fraction(1, 4))
+            g.add_edge((b0, t)); g.add_edge((t, b1))
+            g.add_edge((t, n1), EdgeType.HADAMARD); g.add_edge((n1, v1), EdgeType.HADAMARD)
+            g.add_edge((t, n2), EdgeType.HADAMARD); g.add_edge((n2, v2), EdgeType.HADAMARD)
+            g.set_inputs((b0,)); g.set_outputs((b1,))
+            return g
+
+        g_tel = teleport_reduce(build())
+        for c_val in (0, 1):
+            ref = teleport_reduce(build(c_val))
+            got = g_tel.substitute_variables({'c': Fraction(c_val)})
+            self.assertTrue(compare_tensors(ref.to_tensor(), got.to_tensor()),
+                            f"teleport_reduce drifted at c={c_val}")
+
+    def test_unsafe_pauli_push(self):
+        """`unsafe_pauli_push` must preserve the tensor for a boolean Pauli."""
+        g = Graph()
+        c = new_var('c', is_bool=True, registry=g.var_registry)
+        b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+        b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+        v = g.add_vertex(VertexType.Z, 0, 1, phase=Fraction(1, 4))
+        w = g.add_vertex(VertexType.X, 0, 3, phase=c)
+        g.add_edge((b0, v)); g.add_edge((v, w)); g.add_edge((w, b1))
+        g.set_inputs((b0,)); g.set_outputs((b1,))
+
+        orig = g.copy()
+        unsafe_pauli_push(g, v, w)
+        for c_val in (0, 1):
+            self.assertTrue(tensors_match(g, orig, c=c_val),
+                            f"unsafe_pauli_push drifted at c={c_val}")
+
     def test_unsafe_pivot(self):
         """`unsafe_pivot` must preserve the tensor for boolean pivot phases."""
         g = Graph()

--- a/tests/test_boolean_pauli_rewrites.py
+++ b/tests/test_boolean_pauli_rewrites.py
@@ -38,6 +38,55 @@ def tensors_match(g1, g2, **subs):
 
 class TestBooleanPauliRewrites(unittest.TestCase):
 
+    def test_gadget_simp(self):
+        """`gadget_simp` must preserve the tensor for a boolean axel."""
+        g = Graph()
+        c = new_var('c', is_bool=True, registry=g.var_registry)
+        b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+        b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+        t = g.add_vertex(VertexType.Z, 0, 2)
+        n = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+        v = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+        g.add_edge((b0, t)); g.add_edge((t, b1))
+        g.add_edge((t, n), EdgeType.HADAMARD); g.add_edge((n, v), EdgeType.HADAMARD)
+        g.set_inputs((b0,)); g.set_outputs((b1,))
+
+        orig = g.copy()
+        gadget_simp(g)
+        for c_val in (0, 1):
+            self.assertTrue(tensors_match(g, orig, c=c_val),
+                            f"gadget_simp drifted at c={c_val}")
+
+    def test_teleport_reduce(self):
+        """`teleport_reduce` must commute with substitution for a boolean axel.
+
+        Two phase gadgets sharing parity {target}: boolean axel `c` and
+        constant pi axel, both with T leaves.
+        """
+        def build(c_val=None):
+            g = Graph()
+            c = (new_var('c', is_bool=True, registry=g.var_registry)
+                 if c_val is None else Fraction(c_val))
+            b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+            b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+            t = g.add_vertex(VertexType.Z, 0, 2)
+            n1 = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+            v1 = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+            n2 = g.add_vertex(VertexType.Z, -1, 2, phase=Fraction(1))
+            v2 = g.add_vertex(VertexType.Z, -2, 2, phase=Fraction(1, 4))
+            g.add_edge((b0, t)); g.add_edge((t, b1))
+            g.add_edge((t, n1), EdgeType.HADAMARD); g.add_edge((n1, v1), EdgeType.HADAMARD)
+            g.add_edge((t, n2), EdgeType.HADAMARD); g.add_edge((n2, v2), EdgeType.HADAMARD)
+            g.set_inputs((b0,)); g.set_outputs((b1,))
+            return g
+
+        g_tel = teleport_reduce(build())
+        for c_val in (0, 1):
+            ref = teleport_reduce(build(c_val))
+            got = g_tel.substitute_variables({'c': Fraction(c_val)})
+            self.assertTrue(compare_tensors(ref.to_tensor(), got.to_tensor()),
+                            f"teleport_reduce drifted at c={c_val}")
+
     def test_unsafe_pauli_push(self):
         """`unsafe_pauli_push` skips a boolean Pauli by default and
         preserves the tensor when opted in via ``apply_to_boolean_axels=True``."""


### PR DESCRIPTION
## Description

Adds regression tests for issue #436. Tests will currently fail so this isn't intended to be merged, but rather to act as a guide for fixes.

## Related issue

#436

## Checklist
- [ ] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [ ] For new features: I have updated the documentation.
- [ ] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [ ] I have added an entry to CHANGELOG.md describing my change.