### PR TITLE
add an `apply_to_boolean_axels` parameter to `unsafe_pauli_push`, defaults to skip boolean Pauli axels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).
 - The symbolic expression parser (`pyzx.symbolic.parse`) now accepts division, e.g., `theta/2` or `(x + y)/2`. Divisors must be rational (or complex) constants; division by an integer produces an exact `Fraction` coefficient. As a side effect, `^` binds tighter than `*` and `/`. (by @dlyongemallo)
 - Regression test for `unsafe_pivot` with boolean pivot phases (by @dlyongemallo).
+- `apply_to_boolean_axels` opt-in flag to `(unsafe_)pauli_push`, so boolean parameters are not transformed into non-boolean phase by default (by @dlyongemallo).
 
 ### Changed
 - `Multigraph.edge(s, t)` now raises `ValueError` on ambiguous mixed-type parallel edges or when no matching edge exists, instead of silently returning one; pass `et` to disambiguate. The `et` default is now `None` on `BaseGraph.edge` (`GraphS.edge` and `GraphIG.edge` ignore it). Internal callers were updated to match; as a side effect, `PauliWeb.add_edge` and `PauliWeb.graph_with_errors` now propagate this error rather than silently preferring the `SIMPLE` edge (by @dlyongemallo).

--- a/pyzx/rewrite_rules/push_pauli_rule.py
+++ b/pyzx/rewrite_rules/push_pauli_rule.py
@@ -22,6 +22,11 @@ The standard version of the applier will automatically call the basic checker, w
 of the applier will assume that the given input is correct and will apply the rule without running the check first.
 
 This rewrite rule can be called using simplify.push_pauli_rewrite.apply(g, v, w).
+
+To opt in to pushing a symbolic boolean Poly axel through a non-Pauli spider (which converts the
+boolean parameter into a non-boolean phase), call :func:`pauli_push` or :func:`unsafe_pauli_push`
+directly with ``apply_to_boolean_axels=True``. (Note: The ``simplify.push_pauli_rewrite`` wrapper
+does not forward this keyword.)
 """
 
 __all__ = ['check_pauli',
@@ -32,8 +37,9 @@ from fractions import Fraction
 
 from typing import List, Dict, Tuple
 
-from pyzx.utils import EdgeType, VertexType, FractionLike, phase_is_pauli, vertex_is_zx, toggle_vertex, is_standard_hbox
+from pyzx.utils import EdgeType, VertexType, FractionLike, phase_is_pauli, push_pauli_axel, vertex_is_zx, toggle_vertex, is_standard_hbox
 from pyzx.graph.base import BaseGraph, VT, ET, upair
+from pyzx.symbolic import Poly
 
 def check_pauli(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
     """Checks if a w is a Pauli and v is a spider we can push it through
@@ -66,17 +72,20 @@ def check_pauli(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
     return False
 
 
-def pauli_push(g: BaseGraph[VT,ET], v:VT,w:VT) -> bool:
+def pauli_push(g: BaseGraph[VT,ET], v:VT,w:VT, apply_to_boolean_axels: bool = False) -> bool:
     """Pushes a Pauli (i.e. a pi phase) through another spider."""
-    if check_pauli(g, v, w): return unsafe_pauli_push(g, v, w)
+    if check_pauli(g, v, w): return unsafe_pauli_push(g, v, w, apply_to_boolean_axels=apply_to_boolean_axels)
     return False
 
 
-def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
+def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT, apply_to_boolean_axels: bool = False) -> bool:
     """Pushes a Pauli (i.e. a pi phase) through another spider.
     :param g: Graph to push to
     :param v: Vertex to push through
-    :param w: Pauli getting pushed"""
+    :param w: Pauli getting pushed
+    :param apply_to_boolean_axels: If False (default), skip when ``w`` carries a symbolic
+        boolean Poly phase. If True, when ``v`` is a non-Pauli spider this push converts
+        the boolean parameter into a non-boolean phase."""
 
     rem_verts: List[VT] = []
     rem_edges: List[ET] = []
@@ -85,6 +94,8 @@ def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
     # w is a Pauli and v is the spider we are going to push it through
 
     pauli_phase = g.phase(w)
+    if not apply_to_boolean_axels and isinstance(pauli_phase, Poly) and len(pauli_phase.free_vars()) > 0:
+        return False
 
     if g.vertex_degree(w) == 2:
         rem_verts.append(w)
@@ -99,8 +110,9 @@ def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
 
     new_verts = []
     if vertex_is_zx(g.type(v)):
-        g.scalar.add_phase(g.phase(v))
-        g.set_phase(v, (g.phase(v) - 2 * (pauli_phase * g.phase(v))) % 2) # phase*(1-2a): unchanged when a=0, negated when a=1. Multiply phase first to avoid 2*a cancelling mod 2.
+        leaf_phase = g.phase(v)
+        g.scalar.add_phase(pauli_phase * leaf_phase)
+        g.set_phase(v, push_pauli_axel(pauli_phase, leaf_phase))
         t = toggle_vertex(g.type(v))
         p: FractionLike = pauli_phase
     else:

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -29,6 +29,17 @@ from .symbolic import Poly
 FloatInt = Union[float,int]
 FractionLike = Union[Fraction,int,Poly]
 
+def push_pauli_axel(axel: FractionLike, leaf: FractionLike) -> FractionLike:
+    """Return the new ``leaf`` phase acquired when a Pauli ``axel`` is pushed
+    through a spider of the opposite type. Used by
+    :func:`pyzx.rewrite_rules.push_pauli_rule.unsafe_pauli_push`.
+
+    The caller must ensure ``axel`` evaluates to a Pauli phase. The result is
+    undefined for non-Pauli axels.
+    """
+    return (leaf - 2 * (axel * leaf)) % 2
+
+
 def assert_phase_real(phase: FractionLike | complex) -> None:
     """Raise a TypeError if ``phase`` contains complex coefficients.
 

--- a/tests/test_boolean_pauli_rewrites.py
+++ b/tests/test_boolean_pauli_rewrites.py
@@ -20,7 +20,7 @@ from fractions import Fraction
 
 from pyzx.graph import Graph
 from pyzx.utils import EdgeType, VertexType
-from pyzx.symbolic import new_var
+from pyzx.symbolic import Poly, new_var
 from pyzx.simplify import gadget_simp, teleport_reduce
 from pyzx.rewrite_rules.push_pauli_rule import unsafe_pauli_push
 from pyzx.rewrite_rules.pivot_rule import unsafe_pivot
@@ -37,6 +37,36 @@ def tensors_match(g1, g2, **subs):
 
 
 class TestBooleanPauliRewrites(unittest.TestCase):
+
+    def test_unsafe_pauli_push(self):
+        """`unsafe_pauli_push` skips a boolean Pauli by default and
+        preserves the tensor when opted in via ``apply_to_boolean_axels=True``."""
+        def build():
+            g = Graph()
+            c = new_var('c', is_bool=True, registry=g.var_registry)
+            b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+            b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+            v = g.add_vertex(VertexType.Z, 0, 1, phase=Fraction(1, 4))
+            w = g.add_vertex(VertexType.X, 0, 3, phase=c)
+            g.add_edge((b0, v)); g.add_edge((v, w)); g.add_edge((w, b1))
+            g.set_inputs((b0,)); g.set_outputs((b1,))
+            return g, v, w
+
+        # Default path: return False and leave the graph untouched.
+        g_default, v, w = build()
+        self.assertFalse(unsafe_pauli_push(g_default, v, w))
+        self.assertEqual(g_default.phase(v), Fraction(1, 4))
+
+        # Opt-in path: rewrite runs and the resulting tensor matches the
+        # original for each substitution of the boolean axel.
+        g_optin, v, w = build()
+        orig = g_optin.copy()
+        self.assertTrue(unsafe_pauli_push(g_optin, v, w, apply_to_boolean_axels=True))
+        # v's phase should now depend on c (a Poly), not be the original Fraction.
+        self.assertIsInstance(g_optin.phase(v), Poly)
+        for c_val in (0, 1):
+            self.assertTrue(tensors_match(g_optin, orig, c=c_val),
+                            f"unsafe_pauli_push drifted at c={c_val}")
 
     def test_unsafe_pivot(self):
         """`unsafe_pivot` must preserve the tensor for boolean pivot phases."""


### PR DESCRIPTION

## Description

Pushing a boolean axel through a non-Pauli spider converted a boolean parameter into a non-boolean phase, which might be undesirable behaviour. This adds an opt-in flag `apply_to_boolean_axels` so the user has a choice.

## Related issue

https://github.com/zxcalc/pyzx/issues/436#issuecomment-4338858426

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.