### PR TITLE
Issue#88 collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - Regression test for `unsafe_pivot` with boolean pivot phases (by @dlyongemallo).
 - Added support for zooming in D3 drawings (by @doczenwiry).
 - `apply_to_boolean_axels` opt-in flag to `(unsafe_)pauli_push`, so boolean parameters are not transformed into non-boolean phase by default (by @dlyongemallo).
+- Added support for collision detection in D3 drawings (by @doczenwiry).
 
 ### Changed
 - `Multigraph.edge(s, t)` now raises `ValueError` on ambiguous mixed-type parallel edges or when no matching edge exists, instead of silently returning one; pass `et` to disambiguate. The `et` default is now `None` on `BaseGraph.edge` (`GraphS.edge` and `GraphIG.edge` ignore it). Internal callers were updated to match; as a side effect, `PauliWeb.add_edge` and `PauliWeb.graph_with_errors` now propagate this error rather than silently preferring the `SIMPLE` edge (by @dlyongemallo).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - Regression test for `unsafe_pivot` with boolean pivot phases (by @dlyongemallo).
 - Added support for zooming in D3 drawings (by @doczenwiry).
 - `apply_to_boolean_axels` opt-in flag to `(unsafe_)pauli_push`, so boolean parameters are not transformed into non-boolean phase by default (by @dlyongemallo).
-- Added support for collision detection in D3 drawings (by @doczenwiry).
+- Added support for the detection/highlighting of overlapping nodes in D3 drawings (by @doczenwiry).
 
 ### Changed
 - `Multigraph.edge(s, t)` now raises `ValueError` on ambiguous mixed-type parallel edges or when no matching edge exists, instead of silently returning one; pass `et` to disambiguate. The `et` default is now `None` on `BaseGraph.edge` (`GraphS.edge` and `GraphIG.edge` ignore it). Internal callers were updated to match; as a side effect, `PauliWeb.add_edge` and `PauliWeb.graph_with_errors` now propagate this error rather than silently preferring the `SIMPLE` edge (by @dlyongemallo).

--- a/doc/notebooks/gettingstarted.ipynb
+++ b/doc/notebooks/gettingstarted.ipynb
@@ -1361,7 +1361,7 @@
     "\n",
     "If you are running inside a Jupyter notebook, circuits can be easily visualized using the zx.draw() function.\n",
     "\n",
-    "This draw function by default uses the D3 Javascript library to draw the diagram. You can zoom in/out of the diagram by scrolling up/down on the mouse wheel and reset the zoom level by clicking on the mouse wheel. If it doesn't work, use draw_matplotlib() as shown above instead.  When not running in a Jupyter notebook `zx.draw` returns a matplotlib figure instead."
+    "This draw function by default uses the D3 Javascript library to draw the diagram. You can zoom in/out of the diagram by scrolling up/down on the mouse wheel and reset the zoom level by clicking on the mouse wheel. If it doesn't work, use draw_matplotlib() as shown above instead. Any nodes that are overlapping on the diagram will be highlighted with a dashed black circle filled in yellow and the number of overlapping nodes will be reported at the top-left of the diagram. When not running in a Jupyter notebook `zx.draw` returns a matplotlib figure instead."
    ]
   },
   {

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -71,17 +71,14 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
 
     let colliding_nodes = 0
     graph.nodes.forEach(function (node) {
-        // Initialisation for collision detection
-        // console.log(`Node : ${d.name}@(${d.x},${d.y})`)
-
-        // These four constants represent the boundaries of the box that must be explored for collisions.
+        // These four constants represent the boundaries of the box that must be explored for colliding nodes.
         const xmin = node.x - diameter; const xmax = node.x + diameter;
         const ymin = node.y - diameter; const ymax = node.y + diameter;
         let collision_detected = false
         node_space.visit((quadnode, xL, yT, xR, yB) => {
             // A leaf may contain either a single node or multiple coincident nodes
             while (quadnode && !quadnode.length && !collision_detected) {
-                // The node collides with the one contained in the quadnode if they are closer than 2 * node_size
+                // The node collides with the one contained in the quadnode if they are closer than the diameter
                 let other = quadnode.data;
                 let dx = other.x - node.x;
                 let dy = other.y - node.y;

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -60,6 +60,84 @@ var symbolGround = {
     }
 }
 
+function detect_collisions(graph, node_size, node_space, collision_markers) {
+    // Purge the old collision markers.
+    collision_markers.selectAll().remove()
+
+    // Used for clustering colliding nodes together.
+    const clustering = new Map();
+
+    const diameter = 2 * node_size;
+    // Comparison against the square of the diameter to avoid computing an expensive sqrt(..)
+    const diameter_squared = diameter**2;
+    // console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
+
+    graph.nodes.forEach(function (d) {
+        // Initialisation for collision detection
+        // console.log(`Node : ${d.name}@(${d.x},${d.y})`)
+
+        // These four constants represent the boundaries of the box that must be explored for collisions.
+        const xmin = d.x - diameter; const xmax = d.x + diameter;
+        const ymin = d.y - diameter; const ymax = d.y + diameter;
+        node_space.visit((quadnode, xL, yT, xR, yB)=> {
+            // A leaf may contain either a single node or multiple coincident nodes
+            while (quadnode && !quadnode.length) {
+                // The node contained collides with d if it is closer than 2 * node_size
+                let node = quadnode.data;
+                let dx = node.x - d.x;
+                let dy = node.y - d.y;
+                let distance_squared = dx * dx + dy * dy;
+                if (distance_squared <= diameter_squared && node !== d) {
+                    // console.log(`> Collision : ${node.name}@(${node.x},${node.y})`)
+                    if (!clustering.has(d) && !clustering.has(node)) {
+                        const pair = [d, node];
+                        clustering.set(d, pair);
+                        clustering.set(node, pair);
+                    } else if (clustering.has(d) && !clustering.get(d).includes(node)) {
+                        clustering.get(d).push(node);
+                        clustering.set(node, clustering.get(d));
+                    } else if (clustering.has(node) && !clustering.get(node).includes(d)) {
+                        clustering.get(node).push(d);
+                        clustering.set(d, clustering.get(node));
+                    } else {
+                        const cluster1 = clustering.get(d);
+                        const cluster2 = clustering.get(node);
+                        if (cluster1 !== cluster2) {
+                            cluster2.forEach(n => {
+                                cluster1.push(n);
+                                clustering.set(n, cluster1);
+                            })
+                        }
+                    }
+                }
+                quadnode = quadnode.next;
+            }
+            // Don't explore the children quad-nodes if we are completely outside the neighbourhood of d.
+            return xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
+        });
+    });
+
+    const clusters = new Set(clustering.values())
+    console.log("Collision clusters found :")
+    clusters.forEach(cluster => {
+        let barycenter_x = 0;
+        let barycenter_y = 0;
+        cluster.forEach(n => {
+            barycenter_x += n.x;
+            barycenter_y += n.y;
+        })
+        let barycenter = [barycenter_x / cluster.length , barycenter_y / cluster.length]
+        console.log(`> Cluster@(${barycenter}) involving {${cluster.map(n => n.name)}}`)
+        collision_markers.append("circle")
+            .attr("cx", barycenter[0])
+            .attr("cy", barycenter[1])
+            .attr("r", 3 * node_size)
+            .attr("fill", "rgba(255, 0, 0, 0.5)")
+            .attr("stroke", "red")
+            .attr("stroke-dasharray", "4")
+    })
+}
+
 function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_labels, scalar_str) {
     var ntab = {};
 
@@ -71,40 +149,11 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
         .y(node => node.y)
         .addAll(graph.nodes);
 
-    const diameter = 2 * node_size;
-    const diameter_squared = diameter**2; // Comparison against twice the radius squared to avoid sqrt(..)
-    console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
     graph.nodes.forEach(function(d) {
         ntab[d.name] = d;
         d.selected = false;
         d.previouslySelected = false;
         d.nhd = [];
-
-        // Initialisation for collision detection
-        console.log(`Node : ${d.name}@(${d.x},${d.y})`)
-        d.colliding = false;
-
-        const xmin = d.x - diameter
-        const xmax = d.x + diameter
-        const ymin = d.y - diameter
-        const ymax = d.y + diameter
-        node_space.visit((quadnode, xL, yT, xR, yB)=> {
-            // A leaf may contain either a single node or multiple coincident nodes
-            while (quadnode && !quadnode.length) {
-                // The node contained collides with d if it is closer than 2 * node_size
-                let node = quadnode.data
-                let dx = node.x - d.x
-                let dy = node.y - d.y
-                let distance_squared = dx * dx + dy * dy
-                if (distance_squared <= diameter_squared && node.name !== d.name) {
-                    console.log(`> Collision : ${node.name}@(${node.x},${node.y})`)
-                    d.colliding = true;
-                }
-                quadnode = quadnode.next;
-            }
-            // Don't explore the children quadnodes if we are completely outside the neighbourhood of d.
-            return xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
-        });
     });
 
     var spiders_and_boundaries = graph.nodes.filter(function(d) {
@@ -163,6 +212,10 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
             d3.event.stopImmediatePropagation();
         }
     });
+
+    var collision_markers = canvas.append("g")
+        .attr("class", "collision")
+    detect_collisions(graph, node_size, node_space, collision_markers)
 
     var web = canvas.append("g")
         .attr("class", "web")

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -110,8 +110,8 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
     if (colliding_nodes > 0) {
         console.log(`Colliding nodes detected : ${colliding_nodes}`)
         collision_markers.append("rect")
-            .attr("x", (window_width - 200) / 2)
-            .attr("y", 5)
+            .attr("x", 20)
+            .attr("y", 2)
             .attr("width", 200)
             .attr("height", 20)
             .attr("fill", "rgba(255, 255, 0, 1.0)")
@@ -119,8 +119,8 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
             .attr("stroke-width", "2px")
             .attr("stroke-dasharray", "3");
         collision_markers.append("text")
-            .attr("x", window_width / 2)
-            .attr("y", 20)
+            .attr("x", 120)
+            .attr("y", 16)
             .attr("text-anchor", "middle")
             .text(`Colliding nodes detected : ${colliding_nodes}`)
             .style("fill", "black")
@@ -206,6 +206,7 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
         }
     });
 
+    // This container is used to store the markers that highlight node collisions.
     var collision_markers = canvas.append("g")
         .attr("class", "collision")
     detect_collisions(graph, node_size, node_space, collision_markers, width)

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -99,8 +99,8 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
                 }
                 quadnode = quadnode.next;
             }
-            // Don't explore the children quad-nodes if we are completely outside the neighbourhood of d.
-            return collision_detected || xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
+            // Don't explore this branch if we are completely outside the neighbourhood of d or a collision was detected
+            return collision_detected || xR < xmin || xmax < xL || yB < ymin || ymax < yT;
         });
     });
 

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -73,6 +73,9 @@ function detect_overlaps(graph, node_size, node_space, overlap_markers) {
 
     let nodes_overlapping = 0
     graph.nodes.forEach(function (node) {
+        let node_radius = node_size;
+        if (node.t === 0) { node_radius *= 0.5; }
+        else if (node.t === 4) { node_radius *= 0.25; }
         // These four constants represent the boundaries of the box that must be explored for overlapping nodes.
         const xmin = node.x - diameter; const xmax = node.x + diameter;
         const ymin = node.y - diameter; const ymax = node.y + diameter;
@@ -85,7 +88,11 @@ function detect_overlaps(graph, node_size, node_space, overlap_markers) {
                 let dx = other.x - node.x;
                 let dy = other.y - node.y;
                 let distance_squared = dx * dx + dy * dy;
-                if (distance_squared <= diameter_squared && other !== node) {
+                let other_radius = node_size;
+                if (other.t === 0) { other_radius *= 0.5; }
+                else if (other.t === 4) { other_radius *= 0.25; }
+                let minimal_distance_squared = (node_radius + other_radius)**2;
+                if (distance_squared <= minimal_distance_squared && other !== node) {
                     console.log(`> Overlap detected for ${node.name}@(${node.x},${node.y}) by ${other.name}`);
                     overlap_markers.append("circle")
                         .attr("cx", node.x)

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -60,32 +60,34 @@ var symbolGround = {
     }
 }
 
-function detect_collisions(graph, node_size, node_space, collision_markers, window_width) {
-    // Purge the old collision markers.
-    collision_markers.selectAll("*").remove()
+// Function to detect overlapping nodes. The approach uses a quadtree of nodes that can be efficiently queried
+// to consider only the nodes in a region of interest around some node. See https://d3js.org/d3-quadtree.
+function detect_overlaps(graph, node_size, node_space, overlap_markers) {
+    // Purge the old overlap markers.
+    overlap_markers.selectAll("*").remove()
 
     const diameter = 2 * node_size;
     // Comparison against the square of the diameter to avoid computing an expensive sqrt(..)
     const diameter_squared = diameter**2;
     // console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
 
-    let colliding_nodes = 0
+    let nodes_overlapping = 0
     graph.nodes.forEach(function (node) {
-        // These four constants represent the boundaries of the box that must be explored for colliding nodes.
+        // These four constants represent the boundaries of the box that must be explored for overlapping nodes.
         const xmin = node.x - diameter; const xmax = node.x + diameter;
         const ymin = node.y - diameter; const ymax = node.y + diameter;
-        let collision_detected = false
+        let overlap_detected = false
         node_space.visit((quadnode, xL, yT, xR, yB) => {
             // A leaf may contain either a single node or multiple coincident nodes
-            while (quadnode && !quadnode.length && !collision_detected) {
-                // The node collides with the one contained in the quadnode if they are closer than the diameter
+            while (quadnode && !quadnode.length && !overlap_detected) {
+                // The node overlaps with the one contained in the quadnode if they are closer than the diameter
                 let other = quadnode.data;
                 let dx = other.x - node.x;
                 let dy = other.y - node.y;
                 let distance_squared = dx * dx + dy * dy;
                 if (distance_squared <= diameter_squared && other !== node) {
-                    console.log(`> Collision detected for ${node.name}@(${node.x},${node.y}) : ${other.name}`);
-                    collision_markers.append("circle")
+                    console.log(`> Overlap detected for ${node.name}@(${node.x},${node.y}) by ${other.name}`);
+                    overlap_markers.append("circle")
                         .attr("cx", node.x)
                         .attr("cy", node.y)
                         .attr("r", 2.25 * node_size)
@@ -93,20 +95,20 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
                         .attr("stroke", "black")
                         .attr("stroke-width", "2px")
                         .attr("stroke-dasharray", "3");
-                    colliding_nodes += 1;
-                    // Don't search further once a collision has been detected for the node
-                    collision_detected = true
+                    nodes_overlapping += 1;
+                    // Don't search further once an overlap has been detected for the node
+                    overlap_detected = true
                 }
                 quadnode = quadnode.next;
             }
-            // Don't explore this branch if we are completely outside the neighbourhood of d or a collision was detected
-            return collision_detected || xR < xmin || xmax < xL || yB < ymin || ymax < yT;
+            // Don't explore this branch if we are completely outside the neighbourhood of d or an overlap was detected
+            return overlap_detected || xR < xmin || xmax < xL || yB < ymin || ymax < yT;
         });
     });
 
-    if (colliding_nodes > 0) {
-        console.log(`Colliding nodes detected : ${colliding_nodes}`)
-        collision_markers.append("rect")
+    if (nodes_overlapping > 0) {
+        console.log(`Overlapping nodes detected : ${nodes_overlapping}`)
+        overlap_markers.append("rect")
             .attr("x", 20)
             .attr("y", 2)
             .attr("width", 200)
@@ -115,11 +117,11 @@ function detect_collisions(graph, node_size, node_space, collision_markers, wind
             .attr("stroke", "black")
             .attr("stroke-width", "2px")
             .attr("stroke-dasharray", "3");
-        collision_markers.append("text")
+        overlap_markers.append("text")
             .attr("x", 120)
             .attr("y", 16)
             .attr("text-anchor", "middle")
-            .text(`Colliding nodes detected : ${colliding_nodes}`)
+            .text(`Overlapping nodes detected : ${nodes_overlapping}`)
             .style("fill", "black")
             .style("font-family", "sans-serif")
             .style("font-size", "14px");
@@ -133,7 +135,7 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     var groundOffset = 2.5 * node_size;
 
-    // Populate the quadtree of nodes for collision detection.
+    // Populate the quadtree of nodes for overlap detection.
     const node_space = d3.quadtree()
         .x(node => node.x)
         .y(node => node.y)
@@ -203,10 +205,10 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
         }
     });
 
-    // This container is used to store the markers that highlight node collisions.
-    var collision_markers = canvas.append("g")
-        .attr("class", "collision")
-    detect_collisions(graph, node_size, node_space, collision_markers, width)
+    // This container is used to store the markers that highlight overlapping nodes.
+    var overlap_markers = canvas.append("g")
+        .attr("class", "overlap")
+    detect_overlaps(graph, node_size, node_space, overlap_markers)
 
     var web = canvas.append("g")
         .attr("class", "web")
@@ -439,8 +441,8 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
                 .attr("d", web_curve);
         })
         .on("end", () =>
-            // Once the user releases the node, we can perform a new round of collision detection.
-            detect_collisions(graph, node_size, node_space, collision_markers, width)
+            // Once the user releases the node, we can perform a new round of overlapping nodes detection.
+            detect_overlaps(graph, node_size, node_space, overlap_markers)
         );
 
     node.on("mousedown", function(d) {

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -65,11 +65,46 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     var groundOffset = 2.5 * node_size;
 
+    // Populate the quadtree of nodes for collision detection.
+    const node_space = d3.quadtree()
+        .x(node => node.x)
+        .y(node => node.y)
+        .addAll(graph.nodes);
+
+    const diameter = 2 * node_size;
+    const diameter_squared = diameter**2; // Comparison against twice the radius squared to avoid sqrt(..)
+    console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
     graph.nodes.forEach(function(d) {
         ntab[d.name] = d;
         d.selected = false;
         d.previouslySelected = false;
         d.nhd = [];
+
+        // Initialisation for collision detection
+        console.log(`Node : ${d.name}@(${d.x},${d.y})`)
+        d.colliding = false;
+
+        const xmin = d.x - diameter
+        const xmax = d.x + diameter
+        const ymin = d.y - diameter
+        const ymax = d.y + diameter
+        node_space.visit((quadnode, xL, yT, xR, yB)=> {
+            // A leaf may contain either a single node or multiple coincident nodes
+            while (quadnode && !quadnode.length) {
+                // The node contained collides with d if it is closer than 2 * node_size
+                let node = quadnode.data
+                let dx = node.x - d.x
+                let dy = node.y - d.y
+                let distance_squared = dx * dx + dy * dy
+                if (distance_squared <= diameter_squared && node.name !== d.name) {
+                    console.log(`> Collision : ${node.name}@(${node.x},${node.y})`)
+                    d.colliding = true;
+                }
+                quadnode = quadnode.next;
+            }
+            // Don't explore the children quadnodes if we are completely outside the neighbourhood of d.
+            return xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
+        });
     });
 
     var spiders_and_boundaries = graph.nodes.filter(function(d) {
@@ -184,7 +219,8 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
             else return node_size;
         })
         .attr("fill", function(d) { return nodeColor(d.t); })
-        .attr("stroke", "black")
+        // If a collision was detected with d, use red for its stroke.
+        .attr("stroke", function(d) { return d.colliding === true ? "red" : "black"; })
         .attr("class", "selectable");
 
     var hbox = node.filter(function(d) { return d.t == 3; });

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -60,82 +60,75 @@ var symbolGround = {
     }
 }
 
-function detect_collisions(graph, node_size, node_space, collision_markers) {
+function detect_collisions(graph, node_size, node_space, collision_markers, window_width) {
     // Purge the old collision markers.
-    collision_markers.selectAll().remove()
-
-    // Used for clustering colliding nodes together.
-    const clustering = new Map();
+    collision_markers.selectAll("*").remove()
 
     const diameter = 2 * node_size;
     // Comparison against the square of the diameter to avoid computing an expensive sqrt(..)
     const diameter_squared = diameter**2;
     // console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
 
-    graph.nodes.forEach(function (d) {
+    let colliding_nodes = 0
+    graph.nodes.forEach(function (node) {
         // Initialisation for collision detection
         // console.log(`Node : ${d.name}@(${d.x},${d.y})`)
 
         // These four constants represent the boundaries of the box that must be explored for collisions.
-        const xmin = d.x - diameter; const xmax = d.x + diameter;
-        const ymin = d.y - diameter; const ymax = d.y + diameter;
-        node_space.visit((quadnode, xL, yT, xR, yB)=> {
+        const xmin = node.x - diameter; const xmax = node.x + diameter;
+        const ymin = node.y - diameter; const ymax = node.y + diameter;
+        let collision_detected = false
+        node_space.visit((quadnode, xL, yT, xR, yB) => {
             // A leaf may contain either a single node or multiple coincident nodes
-            while (quadnode && !quadnode.length) {
-                // The node contained collides with d if it is closer than 2 * node_size
-                let node = quadnode.data;
-                let dx = node.x - d.x;
-                let dy = node.y - d.y;
+            while (quadnode && !quadnode.length && !collision_detected) {
+                // The node collides with the one contained in the quadnode if they are closer than 2 * node_size
+                let other = quadnode.data;
+                let dx = other.x - node.x;
+                let dy = other.y - node.y;
                 let distance_squared = dx * dx + dy * dy;
-                if (distance_squared <= diameter_squared && node !== d) {
-                    // console.log(`> Collision : ${node.name}@(${node.x},${node.y})`)
-                    if (!clustering.has(d) && !clustering.has(node)) {
-                        const pair = [d, node];
-                        clustering.set(d, pair);
-                        clustering.set(node, pair);
-                    } else if (clustering.has(d) && !clustering.get(d).includes(node)) {
-                        clustering.get(d).push(node);
-                        clustering.set(node, clustering.get(d));
-                    } else if (clustering.has(node) && !clustering.get(node).includes(d)) {
-                        clustering.get(node).push(d);
-                        clustering.set(d, clustering.get(node));
-                    } else {
-                        const cluster1 = clustering.get(d);
-                        const cluster2 = clustering.get(node);
-                        if (cluster1 !== cluster2) {
-                            cluster2.forEach(n => {
-                                cluster1.push(n);
-                                clustering.set(n, cluster1);
-                            })
-                        }
-                    }
+                if (distance_squared <= diameter_squared && other !== node) {
+                    console.log(`> Collision detected for ${node.name}@(${node.x},${node.y}) : ${other.name}`);
+                    collision_markers.append("circle")
+                        .attr("cx", node.x)
+                        .attr("cy", node.y)
+                        .attr("r", 2.25 * node_size)
+                        .attr("fill", "rgba(255, 255, 0, 0.75)")
+                        .attr("stroke", "black")
+                        .attr("stroke-width", "2px")
+                        .attr("stroke-dasharray", "3");
+                    colliding_nodes += 1;
+                    // Don't search further once a collision has been detected for the node
+                    collision_detected = true
                 }
                 quadnode = quadnode.next;
             }
             // Don't explore the children quad-nodes if we are completely outside the neighbourhood of d.
-            return xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
+            return collision_detected || xR < xmin || xmax <= xL || yB < ymin || yT >= ymax;
         });
     });
 
-    const clusters = new Set(clustering.values())
-    console.log("Collision clusters found :")
-    clusters.forEach(cluster => {
-        let barycenter_x = 0;
-        let barycenter_y = 0;
-        cluster.forEach(n => {
-            barycenter_x += n.x;
-            barycenter_y += n.y;
-        })
-        let barycenter = [barycenter_x / cluster.length , barycenter_y / cluster.length]
-        console.log(`> Cluster@(${barycenter}) involving {${cluster.map(n => n.name)}}`)
-        collision_markers.append("circle")
-            .attr("cx", barycenter[0])
-            .attr("cy", barycenter[1])
-            .attr("r", 3 * node_size)
-            .attr("fill", "rgba(255, 0, 0, 0.5)")
-            .attr("stroke", "red")
-            .attr("stroke-dasharray", "4")
-    })
+    if (colliding_nodes > 0) {
+        console.log(`Colliding nodes detected : ${colliding_nodes}`)
+        collision_markers.append("rect")
+            .attr("x", (window_width - 200) / 2)
+            .attr("y", 5)
+            .attr("width", 200)
+            .attr("height", 20)
+            .attr("fill", "rgba(255, 255, 0, 1.0)")
+            .attr("stroke", "black")
+            .attr("stroke-width", "2px")
+            .attr("stroke-dasharray", "3");
+        collision_markers.append("text")
+            .attr("x", window_width / 2)
+            .attr("y", 20)
+            .attr("text-anchor", "middle")
+            .text(`Colliding nodes detected : ${colliding_nodes}`)
+            .style("fill", "black")
+            .style("font-family", "sans-serif")
+            .style("font-size", "14px");
+    } else {
+        console.log("No collisions detected.")
+    }
 }
 
 function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_labels, scalar_str) {
@@ -215,7 +208,7 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     var collision_markers = canvas.append("g")
         .attr("class", "collision")
-    detect_collisions(graph, node_size, node_space, collision_markers)
+    detect_collisions(graph, node_size, node_space, collision_markers, width)
 
     var web = canvas.append("g")
         .attr("class", "web")
@@ -422,15 +415,8 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     // EVENTS FOR DRAGGING AND SELECTION
 
-    node.on("mousedown", function(d) {
-        if (shiftKey) {
-            d3.select(this).selectAll(".selectable").attr("style", nodeStyle(d.selected = !d.selected));
-            d3.event.stopImmediatePropagation();
-        } else if (!d.selected) {
-            node.selectAll(".selectable").attr("style", function(p) { return nodeStyle(p.selected = d === p); });
-        }
-    })
-        .call(d3.drag().on("drag", function(d) {
+    var dragger = d3.drag()
+        .on("drag", function(d) {
             var dx = d3.event.dx;
             var dy = d3.event.dy;
             // node.filter(function(d) { return d.selected; })
@@ -438,8 +424,11 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
             //     .attr("cy", function(d) { return d.y += dy; });
             node.filter(function(d) { return d.selected; })
                 .attr("transform", function(d) {
+                    // We need to update the quadtree of nodes since the position of d is about to change.
+                    node_space.remove(d)
                     d.x += dx;
                     d.y += dy;
+                    node_space.add(d)
                     return "translate(" + d.x + "," + d.y +")";
                 });
 
@@ -450,7 +439,21 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
                 .attr("d", link_curve);
             web.filter(function(d) { return d.source.selected || d.target.selected; })
                 .attr("d", web_curve);
-        }));
+        })
+        .on("end", () =>
+            // Once the user releases the node, we can perform a new round of collision detection.
+            detect_collisions(graph, node_size, node_space, collision_markers, width)
+        );
+
+    node.on("mousedown", function(d) {
+        if (shiftKey) {
+            d3.select(this).selectAll(".selectable").attr("style", nodeStyle(d.selected = !d.selected));
+            d3.event.stopImmediatePropagation();
+        } else if (!d.selected) {
+            node.selectAll(".selectable").attr("style", function(p) { return nodeStyle(p.selected = d === p); });
+        }
+    })
+        .call(dragger);
 
     brush.call(d3.brush().keyModifiers(false)
         .extent([[0, 0], [width, height]])

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -42,6 +42,13 @@ function nodeStyle(selected) {
     return selected ? "stroke-width: 2px; stroke: #00f" : "stroke-width: 1.5px";
 }
 
+function nodeRadius(t, node_size) {
+    let r = node_size;
+    if (t === 0) { r *= 0.50; }
+    else if (t === 4) { r *= 0.25; }
+    return r;
+}
+
 var symbolGround = {
     draw: function(context, size){
         let s = size/2;
@@ -60,43 +67,56 @@ var symbolGround = {
     }
 }
 
+function get_visual_center(node, node_size) {
+    let vx = node.x;
+    let vy = node.y;
+    if (node.t === 5) {
+        vx += node_size / 2;
+    }
+    return [vx, vy];
+}
+
 // Function to detect overlapping nodes. The approach uses a quadtree of nodes that can be efficiently queried
 // to consider only the nodes in a region of interest around some node. See https://d3js.org/d3-quadtree.
-function detect_overlaps(graph, node_size, node_space, overlap_markers) {
+// n.b. all nodes are treated as circles, an approximation which may introduce some false positives.
+function detect_overlaps(graph, node_size, overlap_markers, overlap_summary) {
+    // Populate the quadtree of nodes for overlap detection.
+    const node_space = d3.quadtree()
+        .x(node => node.x)
+        .y(node => node.y)
+        .addAll(graph.nodes);
+
     // Purge the old overlap markers.
     overlap_markers.selectAll("*").remove()
 
-    const diameter = 2 * node_size;
-    // Comparison against the square of the diameter to avoid computing an expensive sqrt(..)
-    const diameter_squared = diameter**2;
     // console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
+    const diameter = 2 * node_size;
 
     let nodes_overlapping = 0
     graph.nodes.forEach(function (node) {
-        let node_radius = node_size;
-        if (node.t === 0) { node_radius *= 0.5; }
-        else if (node.t === 4) { node_radius *= 0.25; }
+        let current_radius = nodeRadius(node.t, node_size);
+        let [ node_vx , node_vy ] = get_visual_center(node, node_size);
         // These four constants represent the boundaries of the box that must be explored for overlapping nodes.
         const xmin = node.x - diameter; const xmax = node.x + diameter;
         const ymin = node.y - diameter; const ymax = node.y + diameter;
-        let overlap_detected = false
+        let overlap_detected = false;
         node_space.visit((quadnode, xL, yT, xR, yB) => {
             // A leaf may contain either a single node or multiple coincident nodes
             while (quadnode && !quadnode.length && !overlap_detected) {
                 // The node overlaps with the one contained in the quadnode if they are closer than the diameter
                 let other = quadnode.data;
-                let dx = other.x - node.x;
-                let dy = other.y - node.y;
+                let [ other_vx, other_vy ] = get_visual_center(other, node_size);
+                let dx = other_vx - node_vx;
+                let dy = other_vy - node_vy;
                 let distance_squared = dx * dx + dy * dy;
-                let other_radius = node_size;
-                if (other.t === 0) { other_radius *= 0.5; }
-                else if (other.t === 4) { other_radius *= 0.25; }
-                let minimal_distance_squared = (node_radius + other_radius)**2;
+                let other_radius = nodeRadius(other.t, node_size);
+                let minimal_distance_squared = (current_radius + other_radius)**2;
+                // Comparison against the square of the distance to avoid computing an expensive sqrt(..)
                 if (distance_squared <= minimal_distance_squared && other !== node) {
-                    console.log(`> Overlap detected for ${node.name}@(${node.x},${node.y}) by ${other.name}`);
+                    // console.log(`> Overlap detected for ${node.name}@(${node.x},${node.y}) by ${other.name}`);
                     overlap_markers.append("circle")
-                        .attr("cx", node.x)
-                        .attr("cy", node.y)
+                        .attr("cx", node_vx)
+                        .attr("cy", node_vy)
                         .attr("r", 2.25 * node_size)
                         .attr("fill", "rgba(255, 255, 0, 0.75)")
                         .attr("stroke", "black")
@@ -104,7 +124,7 @@ function detect_overlaps(graph, node_size, node_space, overlap_markers) {
                         .attr("stroke-dasharray", "3");
                     nodes_overlapping += 1;
                     // Don't search further once an overlap has been detected for the node
-                    overlap_detected = true
+                    overlap_detected = true;
                 }
                 quadnode = quadnode.next;
             }
@@ -114,26 +134,26 @@ function detect_overlaps(graph, node_size, node_space, overlap_markers) {
     });
 
     if (nodes_overlapping > 0) {
-        console.log(`Overlapping nodes detected : ${nodes_overlapping}`)
-        overlap_markers.append("rect")
-            .attr("x", 20)
-            .attr("y", 2)
-            .attr("width", 200)
-            .attr("height", 20)
+        // console.log(`Overlapping nodes detected : ${nodes_overlapping}`)
+        let text = overlap_summary.append("text")
+            .attr("x", 190)
+            .attr("y", 16)
+            .attr("text-anchor", "middle")
+            .text(`${nodes_overlapping} overlapping nodes detected`)
+            .style("fill", "black")
+            .style("font-family", "sans-serif")
+            .style("font-size", "14px");
+        let box = text.node().getBBox();
+        let padding_h = 2, padding_v = 1;
+        overlap_summary.insert("rect", "text") // Place rectangle under text
+            .attr("x", box.x - padding_h)
+            .attr("y", box.y - padding_v)
+            .attr("width", box.width + (2 * padding_h))
+            .attr("height", box.height + (2 * padding_v))
             .attr("fill", "rgba(255, 255, 0, 1.0)")
             .attr("stroke", "black")
             .attr("stroke-width", "2px")
             .attr("stroke-dasharray", "3");
-        overlap_markers.append("text")
-            .attr("x", 120)
-            .attr("y", 16)
-            .attr("text-anchor", "middle")
-            .text(`Overlapping nodes detected : ${nodes_overlapping}`)
-            .style("fill", "black")
-            .style("font-family", "sans-serif")
-            .style("font-size", "14px");
-    } else {
-        console.log("No collisions detected.")
     }
 }
 
@@ -141,12 +161,6 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
     var ntab = {};
 
     var groundOffset = 2.5 * node_size;
-
-    // Populate the quadtree of nodes for overlap detection.
-    const node_space = d3.quadtree()
-        .x(node => node.x)
-        .y(node => node.y)
-        .addAll(graph.nodes);
 
     graph.nodes.forEach(function(d) {
         ntab[d.name] = d;
@@ -192,14 +206,14 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
     // SETUP FOR ZOOMING
     // Based on https://observablehq.com/@d3/zoom-to-bounding-box
     // The canvas is needed to consistently scale all drawn elements across viewers (Jupyter & web browsers).
-    var canvas = svg.append("g")
+    var canvas = svg.append("g");
 
     var zoomer = d3.zoom()
         .scaleExtent([1, 8])
         .on("zoom", function () {
             canvas.attr("transform", d3.event.transform);
-        })
-    svg.call(zoomer) // Attach the zooming behavior to the SVG
+        });
+    svg.call(zoomer); // Attach the zooming behavior to the SVG
     svg.on("mousedown", function () {
         // Handle the resetting of the zoom level when clicking the wheel button
         if (d3.event.button === 1) {
@@ -213,9 +227,10 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
     });
 
     // This container is used to store the markers that highlight overlapping nodes.
+    var overlap_summary = svg.append("g")
+        .attr("class", "overlap_summary");
     var overlap_markers = canvas.append("g")
-        .attr("class", "overlap")
-    detect_overlaps(graph, node_size, node_space, overlap_markers)
+        .attr("class", "overlap");
 
     var web = canvas.append("g")
         .attr("class", "web")
@@ -266,14 +281,9 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     node.filter(function(d) { return d.t != 3 && d.t != 5 && d.t != 6; })
         .append("circle")
-        .attr("r", function(d) {
-            if (d.t == 0) return 0.5 * node_size;
-            else if (d.t == 4) return 0.25 * node_size;
-            else return node_size;
-        })
+        .attr("r", d => nodeRadius(d.t, node_size))
         .attr("fill", function(d) { return nodeColor(d.t); })
-        // If a collision was detected with d, use red for its stroke.
-        .attr("stroke", function(d) { return d.colliding === true ? "red" : "black"; })
+        .attr("stroke", "black")
         .attr("class", "selectable");
 
     var hbox = node.filter(function(d) { return d.t == 3; });
@@ -384,6 +394,9 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
 
     update_hboxes();
 
+    // Perform the initial round of overlap detection
+    detect_overlaps(graph, node_size, overlap_markers, overlap_summary);
+
     var link_curve = function(d) {
         var x1 = d.source.x, x2 = d.target.x, y1 = d.source.y, y2 = d.target.y;
         if (x1 == x2 && y1 == y2 && d.num_parallel == 1) {
@@ -431,11 +444,8 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
             //     .attr("cy", function(d) { return d.y += dy; });
             node.filter(function(d) { return d.selected; })
                 .attr("transform", function(d) {
-                    // We need to update the quadtree of nodes since the position of d is about to change.
-                    node_space.remove(d)
                     d.x += dx;
                     d.y += dy;
-                    node_space.add(d)
                     return "translate(" + d.x + "," + d.y +")";
                 });
 
@@ -449,7 +459,7 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
         })
         .on("end", () =>
             // Once the user releases the node, we can perform a new round of overlapping nodes detection.
-            detect_overlaps(graph, node_size, node_space, overlap_markers)
+            detect_overlaps(graph, node_size, overlap_markers, overlap_summary)
         );
 
     node.on("mousedown", function(d) {

--- a/pyzx/js/zx_viewer.inline.js
+++ b/pyzx/js/zx_viewer.inline.js
@@ -88,6 +88,7 @@ function detect_overlaps(graph, node_size, overlap_markers, overlap_summary) {
 
     // Purge the old overlap markers.
     overlap_markers.selectAll("*").remove()
+    overlap_summary.selectAll("*").remove()
 
     // console.log(`Space size : ${node_space.size()} [ns:${node_size}, d:${diameter}, r^2:${diameter_squared}]`)
     const diameter = 2 * node_size;
@@ -373,7 +374,7 @@ function showGraph(tag, graph, width, height, scale, node_size, auto_hbox, show_
                     }
                 }
 
-                offset = 0.25 * scale;
+                let offset = 0.25 * scale;
 
                 if (sz != 0) {
                     x = (x/sz) + offset;

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -23,6 +23,11 @@
    "metadata": {},
    "source": [
     "g = pyzx.generate.cnots(64, 512, seed=42)\n",
+    "\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.00)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.25)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.50)\n",
+    "\n",
     "pyzx.draw(g, labels=True)"
    ],
    "outputs": [],
@@ -35,9 +40,9 @@
    "source": [
     "g = pyzx.generate.CNOT_HAD_PHASE_circuit(16, 48, seed=42).to_graph()\n",
     "\n",
-    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.40)\n",
-    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=19.40)\n",
-    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=31.00)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=25.75)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=13.25)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=8, row=19.40)\n",
     "\n",
     "pyzx.draw(g, labels=True)"
    ],
@@ -50,21 +55,26 @@
    "metadata": {},
    "source": [
     "g = pyzx.generate.cliffords(64, 512, t_gates=True, seed=42)\n",
+    "\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.00)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.25)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.50)\n",
+    "\n",
     "pyzx.draw(g, labels=True)"
    ],
    "outputs": [],
    "execution_count": null
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "id": "dfda814b03c19e35",
+   "metadata": {},
    "source": [
     "# For testing with H-boxes\n",
     "c = pyzx.Circuit.load('../circuits/Fast/mod5_4_before')\n",
     "print(c.gates)\n",
     "pyzx.draw(c)"
    ],
-   "id": "dfda814b03c19e35",
    "outputs": [],
    "execution_count": null
   }

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -54,6 +54,19 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# For testing with H-boxes\n",
+    "c = pyzx.Circuit.load('../circuits/Fast/mod5_4_before')\n",
+    "print(c.gates)\n",
+    "pyzx.draw(c)"
+   ],
+   "id": "dfda814b03c19e35",
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -77,6 +77,19 @@
    ],
    "outputs": [],
    "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# For testing with H-boxes\n",
+    "c = pyzx.Circuit.load('../circuits/Fast/mod5_4_before')\n",
+    "print(c.gates)\n",
+    "pyzx.draw(c, auto_hbox=True)"
+   ],
+   "id": "4b97e6a1d1aa5edc",
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -12,7 +12,7 @@
     "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.80)\n",
     "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=33.20)\n",
     "\n",
-    "pyzx.draw(g, labels=True)"
+    "pyzx.draw(g, labels=True, show_scalar=True)"
    ],
    "outputs": [],
    "execution_count": null

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -9,6 +9,9 @@
     "\n",
     "g = pyzx.generate.cnots(16, 48, seed=42)\n",
     "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.40)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=19.40)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=31.00)\n",
+    "\n",
     "pyzx.draw(g, labels=True)"
    ],
    "outputs": [],

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -3,69 +3,68 @@
   {
    "cell_type": "code",
    "id": "initial_id",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "import pyzx\n",
     "\n",
     "g = pyzx.generate.cnots(16, 48, seed=42)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.40)\n",
     "pyzx.draw(g, labels=True)"
    ],
    "outputs": [],
    "execution_count": null
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "id": "d5296e2f9f733e85",
+   "metadata": {},
    "source": [
     "g = pyzx.generate.cnots(64, 512, seed=42)\n",
     "pyzx.draw(g, labels=True)"
    ],
-   "id": "d5296e2f9f733e85",
    "outputs": [],
    "execution_count": null
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "id": "9d6f680120a1ad16",
+   "metadata": {},
    "source": [
     "g = pyzx.generate.CNOT_HAD_PHASE_circuit(16, 48, seed=42).to_graph()\n",
     "pyzx.draw(g, labels=True)"
    ],
-   "id": "9d6f680120a1ad16",
    "outputs": [],
    "execution_count": null
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "id": "92a381bc50c29d70",
+   "metadata": {},
    "source": [
     "g = pyzx.generate.cliffords(64, 512, t_gates=True, seed=42)\n",
     "pyzx.draw(g, labels=True)"
    ],
-   "id": "92a381bc50c29d70",
    "outputs": [],
    "execution_count": null
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.14.3"
   }
  },
  "nbformat": 4,

--- a/scratchpads/issue#88.ipynb
+++ b/scratchpads/issue#88.ipynb
@@ -9,8 +9,8 @@
     "\n",
     "g = pyzx.generate.cnots(16, 48, seed=42)\n",
     "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.40)\n",
-    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=19.40)\n",
-    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=31.00)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.80)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=33.20)\n",
     "\n",
     "pyzx.draw(g, labels=True)"
    ],
@@ -34,6 +34,11 @@
    "metadata": {},
    "source": [
     "g = pyzx.generate.CNOT_HAD_PHASE_circuit(16, 48, seed=42).to_graph()\n",
+    "\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=0, row=32.40)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=19.40)\n",
+    "g.add_vertex(ty=pyzx.VertexType.X, qubit=6, row=31.00)\n",
+    "\n",
     "pyzx.draw(g, labels=True)"
    ],
    "outputs": [],


### PR DESCRIPTION
## Description
Added support for the detection and highlighting of overlapping nodes. Whenever a node is touched by another, it will be highlighted with a dashed black circle filled in yellow. Furthermore, a box summarising the number of nodes that are overlapping will be drawn at the top-left corner of the figure as long as this number is not zero.

The implementation uses d3-quadtree to query the space of nodes in an efficient way. In order to efficiently detect overlap, all the nodes are assumed to be disks of radius node_size (scaled for BOUNDARY and W_INPUT). The tests include the same circuits as the PR #488 with some overlapping nodes added. A test with an existing circuit including H-boxes has also been added to that same notebook.

The behaviour was tested in Jupyter (running in PyCharm Pro) and JupyterLab (tested on Safari, Firefox & Chrome).

## Related issue
This is 1/3 of Issue #88.

## Possible improvements
The notebook ZXW_demo.ipynb show overlaps detected for W_INPUT and W_OUTPUT nodes even though they do not visibly touch. The overlap condition used falls short for the triangle shape of W_OUTPUT and could be tweaked.

## Checklist
- Tests are included in scratchpads/issue#88.ipynb.
- CHANGELOG.md and documentation (gettingstarted.ipynb) have been updated.
- Comments were added to document the function detect_overlaps(..) added to zx_viewer.inline.js.