### PR TITLE
Enforce type annotations in `pyzx.graph` and `pyzx.circuit`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,13 @@ warn_return_any = false
 warn_unused_configs = true
 
 [[tool.mypy.overrides]]
+module = [
+    "pyzx.graph",
+    "pyzx.circuit"
+]
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
 module = "pyzx.optimize"
 ignore_errors = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 module = [
-    "pyzx.graph",
-    "pyzx.circuit"
+    "pyzx.graph.*",
+    "pyzx.circuit.*"
 ]
 disallow_untyped_defs = true
 

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -15,16 +15,19 @@
 # limitations under the License.
 
 import os
-from typing import Any, Union, Iterator
+from collections.abc import Iterator
 
+from typing import Any, Union
 import numpy as np
 
-from .gates import (Gate, gate_types, NOT, Y, Z, HAD, XPhase, YPhase, ZPhase, U2, U3, S, T, SX, SWAP, RXX, RZZ, CNOT,
-                    CY, CZ, CHAD, CSX, XCX, CRX, CRY, CRZ, CPhase, CU3, CU, CSWAP, Tofolli, CCZ, ParityPhase, FSim,
-                    Measurement, PhaseGadget, ConditionalGate)
+from pyzx.graph.base import BaseGraph
+from pyzx.utils import EdgeType
 
-from ..graph.base import BaseGraph
-from ..utils import EdgeType
+from .gates import (CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY,
+                    CZ, HAD, NOT, RXX, RZZ, SWAP, SX, U2, U3, XCX,
+                    ConditionalGate, CPhase, FSim, Gate, Measurement,
+                    ParityPhase, PhaseGadget, S, T, Tofolli, XPhase, Y, YPhase,
+                    Z, ZPhase, gate_types)
 
 __all__ = [
     'Gate', 'gate_types', 'NOT', 'Y', 'Z', 'HAD', 'XPhase', 'YPhase', 'ZPhase', 'U2', 'U3', 'S', 'T', 'SX', 'SWAP', 'RXX', 'RZZ', 'CNOT',
@@ -39,7 +42,7 @@ __all__ = [
 
 CircuitLike = Union['Circuit', Gate]
 
-class Circuit(object):
+class Circuit:
     """Class for representing quantum circuits.
 
     This class is mostly just a wrapper for a list of gates with methods for converting
@@ -64,7 +67,7 @@ class Circuit(object):
 
 
     def __str__(self) -> str:
-        return "Circuit({!s} qubits, {!s} bits, {!s} gates)".format(self.qubits,self.bits,len(self.gates))
+        return "Circuit({!s} qubits, {!s} bits, {!s} gates)".format(self.qubits, self.bits, len(self.gates))
 
     def __repr__(self) -> str:
         return str(self)
@@ -135,7 +138,7 @@ class Circuit(object):
         else:
             return False
 
-    def add_gate(self, gate: Union[Gate,str], *args: Any, **kwargs: Any) -> None:
+    def add_gate(self, gate: Gate | str, *args: Any, **kwargs: Any) -> None:
         """Adds a gate to the circuit. ``gate`` can either be
         an instance of a :class:`Gate`, or it can be the name of a gate,
         in which case additional arguments should be given.
@@ -212,11 +215,11 @@ class Circuit(object):
     def tensor(self, other: CircuitLike) -> 'Circuit':
         """Takes the tensor product of two Circuits. Places the second one below the first.
         Can also be done as an operator: `circuit1 @ circuit2`."""
-        if isinstance(other,Gate):
+        if isinstance(other, Gate):
             c2 = Circuit(other._max_target()+1)
             c2.add_gate(other)
             other = c2
-        if not isinstance(other,Circuit):
+        if not isinstance(other, Circuit):
             raise Exception("Cannot tensor type", type(other), "to Circuit")
         c = Circuit(self.qubits + other.qubits)
         c.gates = [g.copy() for g in self.gates]
@@ -285,7 +288,7 @@ class Circuit(object):
 
 
     @staticmethod
-    def from_graph(g:BaseGraph, split_phases:bool=True) -> 'Circuit':
+    def from_graph(g: BaseGraph, split_phases: bool = True) -> 'Circuit':
         """Produces a :class:`Circuit` containing the gates of the given ZX-graph.
         If the ZX-graph is not circuit-like then the behaviour of this function
         is undefined.
@@ -326,7 +329,7 @@ class Circuit(object):
             elide_initial_resets=elide_initial_resets,
         )
 
-    def to_tensor(self, preserve_scalar: bool = True, strategy: str= 'naive') -> np.ndarray:
+    def to_tensor(self, preserve_scalar: bool = True, strategy: str = 'naive') -> np.ndarray:
         """Returns a numpy tensor describing the circuit."""
         return self.to_graph().to_tensor(preserve_scalar, strategy)
 

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import os
-from typing import Union, Iterator
+from typing import Any, Union, Iterator
 
 import numpy as np
 
@@ -81,7 +81,7 @@ class Circuit(object):
         return c
 
 
-    def initialize_qubits(self, initialize_qubits: list[bool]):
+    def initialize_qubits(self, initialize_qubits: list[bool]) -> None:
         """
         Args:
             initialize_qubits: A list of booleans of length equal to the number of qubits in the circuit.
@@ -91,7 +91,7 @@ class Circuit(object):
             raise ValueError("Length of initialize_qubits must be equal to the number of qubits in the circuit.")
         self._initialize_qubits = initialize_qubits
 
-    def postselect_qubits(self, postselect_qubits: list[int]):
+    def postselect_qubits(self, postselect_qubits: list[int]) -> None:
         """
         Args:
             postselect_qubits: A list of integers indicating for each measured qubits, whether it should be
@@ -135,7 +135,7 @@ class Circuit(object):
         else:
             return False
 
-    def add_gate(self, gate: Union[Gate,str], *args, **kwargs) -> None:
+    def add_gate(self, gate: Union[Gate,str], *args: Any, **kwargs: Any) -> None:
         """Adds a gate to the circuit. ``gate`` can either be
         an instance of a :class:`Gate`, or it can be the name of a gate,
         in which case additional arguments should be given.
@@ -150,11 +150,11 @@ class Circuit(object):
             gate = gate_class(*args, **kwargs)
         self.gates.append(gate)
 
-    def prepend_gate(self, gate, *args, **kwargs):
+    def prepend_gate(self, gate: Gate | str, *args: Any, **kwargs: Any) -> None:
         """The same as add_gate, but adds the gate to the start of the circuit, not the end.
         """
         if isinstance(gate, str):
-            gate_class = gates.gate_types[gate]
+            gate_class = gate_types[gate]
             gate = gate_class(*args, **kwargs)
         self.gates.insert(0, gate)
 
@@ -274,10 +274,10 @@ class Circuit(object):
 
     ### MATRIX EMULATION (FOR E.G. Mat2.gauss)
 
-    def row_add(self, q0: int, q1: int):
+    def row_add(self, q0: int, q1: int) -> None:
         self.add_gate("CNOT", q0, q1)
 
-    def col_add(self, q0: int, q1: int):
+    def col_add(self, q0: int, q1: int) -> None:
         self.prepend_gate("CNOT", q1, q0)
 
 
@@ -326,11 +326,11 @@ class Circuit(object):
             elide_initial_resets=elide_initial_resets,
         )
 
-    def to_tensor(self, preserve_scalar:bool=True, strategy:str='naive') -> np.ndarray:
+    def to_tensor(self, preserve_scalar: bool = True, strategy: str= 'naive') -> np.ndarray:
         """Returns a numpy tensor describing the circuit."""
         return self.to_graph().to_tensor(preserve_scalar, strategy)
 
-    def to_matrix(self, preserve_scalar=True, strategy:str='naive') -> np.ndarray:
+    def to_matrix(self, preserve_scalar: bool = True, strategy: str = 'naive') -> np.ndarray:
         """Returns a numpy matrix describing the circuit."""
         return self.to_graph().to_matrix(preserve_scalar, strategy)
 

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -16,13 +16,12 @@
 
 import os
 from collections.abc import Iterator
-
 from typing import Any, Union
+
 import numpy as np
 
-from pyzx.graph.base import BaseGraph
-from pyzx.utils import EdgeType
-
+from ..graph.base import BaseGraph
+from ..utils import EdgeType
 from .gates import (CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY,
                     CZ, HAD, NOT, RXX, RZZ, SWAP, SX, U2, U3, XCX,
                     ConditionalGate, CPhase, FSim, Gate, Measurement,

--- a/pyzx/circuit/emojiparser.py
+++ b/pyzx/circuit/emojiparser.py
@@ -16,6 +16,7 @@
 
 from . import Circuit
 
+
 def circuit_to_emoji(c: Circuit, compress_rows: bool = True) -> str:
     """Turns the circuit into a ZX-Graph.
     If ``compress_rows`` is set, it tries to put single qubit gates on different qubits,

--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -22,11 +22,11 @@ quantum gates for use in the Circuit class.
 import copy
 import math
 from fractions import Fraction
-from typing import TYPE_CHECKING, ClassVar, TypeVar, Generic
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
-from ..utils import EdgeType, VertexType, FractionLike, half_phase, settings
-from ..graph.base import BaseGraph, VT, ET
-from ..symbolic import new_const, new_var, Poly
+from pyzx.graph.base import ET, VT, BaseGraph
+from pyzx.symbolic import Poly, new_const, new_var
+from pyzx.utils import EdgeType, FractionLike, VertexType, half_phase, settings
 
 if TYPE_CHECKING:
     from . import Circuit
@@ -45,7 +45,7 @@ class TargetMapper(Generic[VT]):
     _labels: set[int]
     _max_row: int
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._qubits = {}
         self._rows = {}
         self._prev_vs = {}
@@ -332,8 +332,8 @@ class Gate:
                 mapper: TargetMapper[VT],
                 t: VertexType,
                 l: int, r: int,
-                phase: FractionLike=0,
-                etype: EdgeType=EdgeType.SIMPLE,
+                phase: FractionLike = 0,
+                etype: EdgeType = EdgeType.SIMPLE,
                 ground: bool = False) -> VT:
         v = g.add_vertex(t, mapper.to_qubit(l), r, phase, ground)
         g.add_edge((mapper.prev_vertex(l), v), etype)
@@ -357,7 +357,7 @@ class ZPhase(Gate):
         self.graph_add_node(g,q_mapper, VertexType.Z, self.target, q_mapper.next_row(self.target), self.phase)
         q_mapper.advance_next_row(self.target)
 
-    def to_quipper(self):
+    def to_quipper(self) -> str:
         if not self.print_phase:
             return super().to_quipper()
         return 'QRot["exp(-i%Z)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
@@ -375,7 +375,7 @@ class ZPhase(Gate):
         else: raise Exception("Unsupported phase " + str(phase))
         strings[self.target].append(s)
 
-    def tcount(self):
+    def tcount(self) -> int:
         return 1 if self.phase.denominator > 2 else 0
 
     def split_phases(self) -> list['ZPhase']:
@@ -414,7 +414,7 @@ class S(ZPhase):
     qc_name = 'S'
     quipper_name = 'S'
     print_phase = False
-    def __init__(self, target: int, adjoint:bool=False) -> None:
+    def __init__(self, target: int, adjoint: bool = False) -> None:
         super().__init__(target, Fraction(1,2)*(-1 if adjoint else 1))
         self.adjoint = adjoint
 
@@ -425,7 +425,7 @@ class T(ZPhase):
     qc_name = 'T'
     quipper_name = 'T'
     print_phase = False
-    def __init__(self, target: int, adjoint:bool=False) -> None:
+    def __init__(self, target: int, adjoint: bool = False) -> None:
         super().__init__(target, Fraction(1,4)*(-1 if adjoint else 1))
         self.adjoint = adjoint
 
@@ -434,7 +434,7 @@ class XPhase(Gate):
     qasm_name = 'rx'
     quipper_name = 'XPhase'
     print_phase = True
-    def __init__(self, target: int, phase: FractionLike=0) -> None:
+    def __init__(self, target: int, phase: FractionLike = 0) -> None:
         self.target = target
         self.phase = phase
 
@@ -455,7 +455,7 @@ class XPhase(Gate):
         else: raise Exception("Unsupported phase " + str(phase))
         strings[self.target].append(s)
 
-    def to_quipper(self):
+    def to_quipper(self) -> str:
         if not self.print_phase:
             return super().to_quipper()
         return 'QRot["exp(-i%X)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
@@ -485,7 +485,7 @@ class XPhase(Gate):
         # General case: return normalized XPhase (keeps it as a basic gate).
         return [XPhase(self.target, phase)]
 
-    def tcount(self):
+    def tcount(self) -> int:
         return 1 if self.phase.denominator > 2 else 0
 
     def split_phases(self) -> list[Gate]:
@@ -513,7 +513,7 @@ class SX(XPhase):
     qasm_name = 'sx'
     qasm_name_adjoint = 'sxdg'
     print_phase = False
-    def __init__(self, target: int, adjoint:bool=False) -> None:
+    def __init__(self, target: int, adjoint: bool = False) -> None:
         super().__init__(target, Fraction(1,2)*(-1 if adjoint else 1))
         self.adjoint = adjoint
 
@@ -578,7 +578,7 @@ class YPhase(Gate):
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
-    def tcount(self):
+    def tcount(self) -> int:
         return 1 if self.phase.denominator > 2 else 0
 
 class Y(YPhase):
@@ -751,7 +751,7 @@ class CRX(Gate):
                [CNOT(self.control, self.target)] + \
                U3(self.target, phase, Fraction(-1,2), 0).to_basic_gates()
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -771,7 +771,7 @@ class CRY(Gate):
                YPhase(self.target, -half_phase).to_basic_gates() + \
                [CNOT(self.control, self.target)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -791,7 +791,7 @@ class CRZ(Gate):
                 ZPhase(self.target, -phase),
                 CNOT(self.control, self.target)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -813,7 +813,7 @@ class RXX(Gate):
                 HAD(self.target)] + \
                U2(self.control,Fraction(-1,1),(Fraction(1,1)-self.phase)%2).to_basic_gates()
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -846,7 +846,7 @@ class CHAD(Gate):
                 T(self.target),HAD(self.target),S(self.target),NOT(self.target),S(self.control)]
 
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -877,9 +877,9 @@ class ParityPhase(Gate):
     def copy(self) -> 'ParityPhase':
         return type(self)(self.phase, *self.targets, as_gadget=self.as_gadget)
 
-    def reposition(self, mask, bit_mask = None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'ParityPhase':
         g = self.copy()
-        g.targets = [mask[t] for t in g.targets]
+        g.targets = tuple(mask[t] for t in g.targets)
         return g
 
     def to_basic_gates(self) -> list[Gate]:
@@ -890,7 +890,7 @@ class ParityPhase(Gate):
         p = ZPhase(self.targets[-1], self.phase)
         return cnots + [p] + list(reversed(cnots))
     
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         if self.as_gadget:
             # Create phase gadget structure directly in the graph.
             anchors = []
@@ -904,7 +904,7 @@ class ParityPhase(Gate):
             for gate in self.to_basic_gates():
                 gate.to_graph(g, q_mapper, c_mapper)
 
-    def tcount(self):
+    def tcount(self) -> int:
         return 1 if self.phase.denominator > 2 else 0
 
 
@@ -913,7 +913,7 @@ class PhaseGadget(ParityPhase):
 
     This is equivalent to ParityPhase(phase, *targets, as_gadget=True).
     """
-    def __init__(self, phase: FractionLike, *targets: int):
+    def __init__(self, phase: FractionLike, *targets: int) -> None:
         super().__init__(phase, *targets, as_gadget=True)
 
 
@@ -932,7 +932,7 @@ class FSim(Gate):
     name = 'FSim'
     qsim_name = 'fs'
     print_phase = True
-    def __init__(self, control:int, target:int, theta:FractionLike, phi:FractionLike):
+    def __init__(self, control: int, target: int, theta: FractionLike, phi: FractionLike) -> None:
         # TODO: this version assumes theta is always (pi/2)
         assert theta == Fraction(1, 2)
         self.control = control
@@ -952,7 +952,7 @@ class FSim(Gate):
     def __str__(self) -> str:
         return "FSim({!s}, {!s}, {!s}, {!s})".format(self.control, self.target, self.theta, self.phi)
 
-    def reposition(self, mask, bit_mask=None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'FSim':
         g = self.copy()
         g.control = mask[self.control]
         g.target = mask[self.target]
@@ -1041,7 +1041,7 @@ class FSim(Gate):
         #for gate in self.to_basic_gates():
         #    gate.to_graph(g, q_mapper, c_mapper)
 
-    def tcount(self):
+    def tcount(self) -> int:
         # TODO
         return 0 #1 if self.phase.denominator > 2 else 0
 
@@ -1063,20 +1063,20 @@ class CCZ(Gate):
             return True
         return False
 
-    def _max_target(self):
-        return max([self.target,self.ctrl1,self.ctrl2])
+    def _max_target(self) -> int:
+        return max([self.target, self.ctrl1, self.ctrl2])
 
-    def tcount(self):
+    def tcount(self) -> int:
         return 7
 
-    def reposition(self, mask, bit_mask = None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'CCZ':
         g = self.copy()
         g.target = mask[g.target]
         g.ctrl1 = mask[g.ctrl1]
         g.ctrl2 = mask[g.ctrl2]
         return g
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         c1,c2,t = self.ctrl1, self.ctrl2, self.target
         return [CNOT(c2,t), T(t,adjoint=True),
                 CNOT(c1,t), T(t),CNOT(c2,t),T(t,adjoint=True),
@@ -1101,7 +1101,7 @@ class CCZ(Gate):
         q_mapper.set_next_row(self.ctrl1, r+1)
         q_mapper.set_next_row(self.ctrl2, r+1)
 
-    def to_quipper(self):
+    def to_quipper(self) -> str:
         s = 'QGate["{}"]({!s})'.format(self.quipper_name,self.target)
         s += ' with controls=[+{!s},+{!s}]'.format(self.ctrl1,self.ctrl2)
         s += ' with nocontrol'
@@ -1121,7 +1121,7 @@ class Tofolli(CCZ):
             return True
         return False
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         c1,c2,t = self.ctrl1, self.ctrl2, self.target
         return [HAD(t), CNOT(c2,t), T(t,adjoint=True),
                 CNOT(c1,t), T(t),CNOT(c2,t),T(t,adjoint=True),
@@ -1146,13 +1146,13 @@ class CSWAP(CCZ):
             return True
         return False
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         c, t1, t2 = self.ctrl1, self.ctrl2, self.target
         return [CNOT(control=t2,target=t1)] + \
                Tofolli(c,t1,t2).to_basic_gates() + \
                [CNOT(control=t2,target=t1)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -1166,12 +1166,12 @@ class U2(Gate):  # See https://arxiv.org/pdf/1707.03429.pdf
         self.phi = phi
         self.phases = [theta, phi]
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [ZPhase(self.target,phase=(self.phi-Fraction(1,2))%2),
                 XPhase(self.target,phase=Fraction(1,2)),
                 ZPhase(self.target,phase=(self.theta+Fraction(1,2))%2)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -1186,14 +1186,14 @@ class U3(Gate):  # See equation (5) of https://arxiv.org/pdf/1707.03429.pdf
         self.rho = rho
         self.phases = [theta, phi, rho]
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [ZPhase(self.target,phase=self.rho),
                 XPhase(self.target,phase=Fraction(1,2)),
                 ZPhase(self.target,phase=(self.theta+1)%2),
                 XPhase(self.target,phase=Fraction(1,2)),
                 ZPhase(self.target,phase=(self.phi+3)%2)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -1238,11 +1238,11 @@ class CU(Gate):
         self.gamma = gamma
         self.phases = [theta, phi, rho, gamma]
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [ZPhase(self.control,phase=self.gamma)] + \
                CU3(self.control,self.target,self.theta,self.phi,self.rho).to_basic_gates()
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -1285,11 +1285,11 @@ class InitAncilla(Gate):
             return False
         return self.label == other.label and self.state == other.state
 
-    def get_vertex_info(self):
+    def get_vertex_info(self) -> tuple[VertexType, Fraction]:
         """Returns (VertexType, phase) for this ancilla state."""
         return self.STATE_MAP[self.state]
 
-    def reposition(self, mask, bit_mask=None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'InitAncilla':
         g = self.copy()
         g.label = mask[self.label]
         g.target = g.label
@@ -1313,7 +1313,7 @@ class Reset(Gate):
     """
     name = 'Reset'
 
-    def __init__(self, target: int):
+    def __init__(self, target: int) -> None:
         self.target = target
         self.label = target
 
@@ -1328,7 +1328,7 @@ class Reset(Gate):
     def to_qasm(self) -> str:
         return "reset q[{:d}];".format(self.target)
 
-    def reposition(self, mask, bit_mask=None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'Reset':
         g = self.copy()
         g.target = mask[self.target]
         g.label = g.target
@@ -1346,7 +1346,7 @@ class PostSelect(Gate):
     name = 'PostSelect'
     STATE_MAP = _state_map
 
-    def __init__(self, label: int, state: str = '+'):
+    def __init__(self, label: int, state: str = '+') -> None:
         self.label = label
         self.target = label
         if state not in self.STATE_MAP:
@@ -1366,11 +1366,11 @@ class PostSelect(Gate):
             return False
         return self.label == other.label and self.state == other.state
 
-    def get_vertex_info(self):
+    def get_vertex_info(self) -> tuple[VertexType, Fraction]:
         """Returns (VertexType, phase) for this post-selection state."""
         return self.STATE_MAP[self.state]
 
-    def reposition(self, mask, bit_mask=None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'PostSelect':
         g = self.copy()
         g.label = mask[self.label]
         g.target = g.label
@@ -1398,7 +1398,7 @@ class ConditionalGate(Gate):
     name = 'ConditionalGate'
 
     def __init__(self, condition_register: str, condition_value: int,
-                 inner_gate: 'Gate', register_size: int):
+                 inner_gate: 'Gate', register_size: int) -> None:
         if condition_value < 0 or condition_value >= (1 << register_size):
             raise ValueError(
                 "Condition value {} is out of range for a {}-bit register "
@@ -1437,7 +1437,7 @@ class ConditionalGate(Gate):
             self.condition_register, self.condition_value,
             self.inner_gate.copy(), self.register_size)
 
-    def reposition(self, mask, bit_mask = None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'ConditionalGate':
         g = self.copy()
         g.inner_gate = g.inner_gate.reposition(mask, bit_mask)
         g.target = getattr(g.inner_gate, "target")
@@ -1560,7 +1560,7 @@ class Measurement(Gate):
             g.result_bit = bit_mask[self.result_bit]
         return g
 
-    def to_graph_symbolic_boolean(self, g, q_mapper):
+    def to_graph_symbolic_boolean(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT]) -> None:
         """Represent the measurement as a Z spider with a symbolic-phase leaf.
 
         Places a Z(0) spider on the qubit wire and attaches the classical

--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -24,9 +24,9 @@ import math
 from fractions import Fraction
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
-from pyzx.graph.base import ET, VT, BaseGraph
-from pyzx.symbolic import Poly, new_const, new_var
-from pyzx.utils import EdgeType, FractionLike, VertexType, half_phase, settings
+from ..graph.base import ET, VT, BaseGraph
+from ..symbolic import Poly, new_const, new_var
+from ..utils import EdgeType, FractionLike, VertexType, half_phase, settings
 
 if TYPE_CHECKING:
     from . import Circuit

--- a/pyzx/circuit/graphparser.py
+++ b/pyzx/circuit/graphparser.py
@@ -16,13 +16,15 @@
 
 import warnings
 
+from pyzx.graph import Graph
+from pyzx.graph.base import ET, VT, BaseGraph
+from pyzx.symbolic import Poly, new_var
+from pyzx.utils import EdgeType, FloatInt, VertexType, settings
+
 from . import Circuit
-from .gates import (Gate, InitAncilla, Measurement, PostSelect, Reset, TargetMapper,
-                     ConditionalGate, ZPhase, XPhase, NOT, Z, S, T, SX)
-from ..utils import EdgeType, VertexType, FloatInt, settings
-from ..graph import Graph
-from ..graph.base import BaseGraph, VT, ET
-from ..symbolic import Poly, new_var
+from .gates import (NOT, SX, ConditionalGate, Gate, InitAncilla, Measurement,
+                    PostSelect, Reset, S, T, TargetMapper, XPhase, Z, ZPhase)
+
 
 def _poly_phase_to_conditional_gate(
     phase: Poly, vertex_type: VertexType, qubit: int
@@ -43,9 +45,11 @@ def _poly_phase_to_conditional_gate(
     Both Z- and X-type vertices are supported as the conditional
     inner gate.
     """
-    from fractions import Fraction
-    from ..symbolic import Var
     import re
+    from fractions import Fraction
+
+    from ..symbolic import Var
+
     # Collect all boolean variables across all terms.
     bit_pattern = re.compile(r'^(\w+)\[(\d+)\]$')
     reg_name: str | None = None
@@ -129,7 +133,7 @@ def _poly_phase_to_conditional_gate(
     return ConditionalGate(reg_name, cond_value, inner_gate, reg_size)
 
 
-def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
+def graph_to_circuit(g: BaseGraph[VT, ET], split_phases: bool = True) -> Circuit:
     inputs = g.inputs()
     qs = g.qubits()
     rs = g.rows()
@@ -271,8 +275,8 @@ def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
 
 def circuit_to_graph(
     c: Circuit,
-    compress_rows:bool = True,
-    backend: str | None =None,
+    compress_rows: bool = True,
+    backend: str | None = None,
     initialize_qubits: list[bool] | None = None,
     postselect_qubits: list[int] | None = None,
     elide_initial_resets: bool = False,

--- a/pyzx/circuit/graphparser.py
+++ b/pyzx/circuit/graphparser.py
@@ -16,11 +16,10 @@
 
 import warnings
 
-from pyzx.graph import Graph
-from pyzx.graph.base import ET, VT, BaseGraph
-from pyzx.symbolic import Poly, new_var
-from pyzx.utils import EdgeType, FloatInt, VertexType, settings
-
+from ..graph import Graph
+from ..graph.base import ET, VT, BaseGraph
+from ..symbolic import Poly, new_var
+from ..utils import EdgeType, FloatInt, VertexType, settings
 from . import Circuit
 from .gates import (NOT, SX, ConditionalGate, Gate, InitAncilla, Measurement,
                     PostSelect, Reset, S, T, TargetMapper, XPhase, Z, ZPhase)

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -19,11 +19,10 @@ import math
 import re
 from fractions import Fraction
 
-from pyzx.symbolic import Var, new_var
-from pyzx.symbolic import parse as parse_symbolic_expr
-from pyzx.symbolic import parse_phase_list
-from pyzx.utils import settings
-
+from ..symbolic import Var, new_var
+from ..symbolic import parse as parse_symbolic_expr
+from ..symbolic import parse_phase_list
+from ..utils import settings
 from . import Circuit
 from .gates import (CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY,
                     CZ, HAD, NOT, RXX, RZZ, SWAP, SX, U2, U3, ConditionalGate,

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -422,7 +422,7 @@ class QASMParser(object):
                 raise TypeError("Invalid specification: {}".format(c))
         return gates
 
-    def parse_phase_arg(self, val):
+    def parse_phase_arg(self, val: str) -> Fraction:
         val = val.strip()
         if self._param_subst is not None:
             bound = self._bind_phase_parameters(val)

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -19,17 +19,19 @@ import math
 import re
 from fractions import Fraction
 
+from pyzx.symbolic import Var, new_var
+from pyzx.symbolic import parse as parse_symbolic_expr
+from pyzx.symbolic import parse_phase_list
+from pyzx.utils import settings
+
 from . import Circuit
-from .gates import (
-    CCZ, CHAD, CNOT, ConditionalGate, CPhase, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY, CZ,
-    Gate, HAD, Measurement, NOT, Reset, RXX, RZZ, S, SWAP, SX,
-    T, Tofolli, U2, U3, XPhase, Y, YPhase, Z, ZPhase, qasm_gate_table
-)
-from ..symbolic import Var, new_var, parse as parse_symbolic_expr, parse_phase_list
-from ..utils import settings
+from .gates import (CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY,
+                    CZ, HAD, NOT, RXX, RZZ, SWAP, SX, U2, U3, ConditionalGate,
+                    CPhase, Gate, Measurement, Reset, S, T, Tofolli, XPhase, Y,
+                    YPhase, Z, ZPhase, qasm_gate_table)
 
 
-class QASMParser(object):
+class QASMParser:
     """Class for parsing QASM source files into circuit descriptions."""
 
     def __init__(self) -> None:
@@ -44,7 +46,7 @@ class QASMParser(object):
         self.bit_count: int = 0
         self.circuit: Circuit | None = None
 
-    def parse(self, s: str, strict:bool=True) -> Circuit:
+    def parse(self, s: str, strict: bool = True) -> Circuit:
         self.gates = []
         self.custom_gates = {}
         self.parametrized_gates = {}

--- a/pyzx/circuit/qcparser.py
+++ b/pyzx/circuit/qcparser.py
@@ -17,6 +17,7 @@
 from . import Circuit
 from .gates import *
 
+
 def parse_qc(data: str) -> Circuit:
     """Produces a :class:`Circuit` based on a .qc description of a circuit.
     If a Tofolli gate with more than 2 controls is encountered, ancilla qubits are added.

--- a/pyzx/circuit/qsimparser.py
+++ b/pyzx/circuit/qsimparser.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from fractions import Fraction
+
 from . import Circuit
 from .gates import *
-from fractions import Fraction
+
 
 def parse_qsim(data: str) -> Circuit:
     """Produces a :class:`Circuit` based on a .qsim description of a circuit."""

--- a/pyzx/circuit/quipperparser.py
+++ b/pyzx/circuit/quipperparser.py
@@ -19,6 +19,7 @@ from fractions import Fraction
 
 from . import Circuit
 
+
 def parse_quipper_block(lines: list[str]) -> Circuit:
     start = lines[0]
     end = lines[-1]

--- a/pyzx/circuit/sqasm.py
+++ b/pyzx/circuit/sqasm.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyzx.graph.base import BaseGraph
-from pyzx.rewrite import *
-from pyzx.rewrite_rules import *
-from pyzx.utils import VertexType
-
+from ..graph.base import BaseGraph
+from ..rewrite import RewriteSimpDoubleVertex, RewriteSimpSingleVertex
+from ..rewrite_rules import (check_fuse, check_remove_id, unsafe_fuse,
+                             unsafe_remove_id)
+from ..utils import VertexType
 from .qasmparser import QASMParser
 
 __all__ = ['sqasm']

--- a/pyzx/circuit/sqasm.py
+++ b/pyzx/circuit/sqasm.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .qasmparser import QASMParser
-from ..rewrite_rules import *
-from ..rewrite import *
-
-from pyzx.utils import VertexType
 from pyzx.graph.base import BaseGraph
+from pyzx.rewrite import *
+from pyzx.rewrite_rules import *
+from pyzx.utils import VertexType
 
+from .qasmparser import QASMParser
 
 __all__ = ['sqasm']
 

--- a/pyzx/graph/__init__.py
+++ b/pyzx/graph/__init__.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -16,15 +16,17 @@
 
 __all__ = [
     "Graph",
+    "GraphDiff",
     "EdgeType",
+    "Scalar",
     "VertexType",
     "toggle_edge",
     "vertex_is_zx",
     "toggle_vertex",
 ]
 
+from ..utils import toggle_edge, toggle_vertex, vertex_is_zx
+from .base import EdgeType, VertexType
+from .diff import GraphDiff
 from .graph import Graph
 from .scalar import Scalar
-from .base import EdgeType, VertexType
-from ..utils import toggle_vertex, toggle_edge, vertex_is_zx
-from .diff import GraphDiff

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -430,7 +430,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.set_qubit(vertex, q)
         self.set_row(vertex, r)
 
-    def neighbors(self, vertex: VT) -> Iterable[VT]:
+    def neighbors(self, vertex: VT) -> list[VT]:
         """Returns all neighboring vertices of the given vertex."""
         vs: set[VT] = set()
         for e in self.incident_edges(vertex):

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -19,20 +19,20 @@ from __future__ import annotations
 import copy
 import math
 from collections import Counter
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from fractions import Fraction
 from typing import (TYPE_CHECKING, Any, ClassVar, Generic, Literal, Optional,
                     TypeVar)
 
 import numpy as np
+from typing_extensions import Self
 
-from pyzx.symbolic import Poly, Var, VarRegistry
-from pyzx.tensor import tensor_to_matrix, tensorfy
-from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
-                        assert_phase_real, get_h_box_label, get_z_box_label,
-                        hbox_has_complex_label, set_h_box_label,
-                        set_z_box_label, toggle_edge, vertex_is_zx)
-
+from ..symbolic import Poly, Var, VarRegistry
+from ..tensor import tensor_to_matrix, tensorfy
+from ..utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                     assert_phase_real, get_h_box_label, get_z_box_label,
+                     hbox_has_complex_label, set_h_box_label, set_z_box_label,
+                     toggle_edge, vertex_is_zx)
 from .scalar import Scalar, simplify_poly
 
 if TYPE_CHECKING:
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 
 MT = TypeVar("MT", bound="DocstringMeta") # Used for properly typing the metaclass
-Tvar = TypeVar("Tvar", bound="BaseGraph")
 
 class DocstringMeta(type):
     """Metaclass that allows docstring 'inheritance'."""
@@ -169,8 +168,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns the amount of edges in the graph"""
         return len(list(self.edges(s, t)))
 
-    def vertices(self) -> list[VT]:
-        """Iterator over all the vertices."""
+    def vertices(self) -> Collection[VT]:
+        """Collection of all the vertices."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
     def edges(self, s: VT | None = None, t: VT | None = None) -> Iterable[ET]:
@@ -430,7 +429,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.set_qubit(vertex, q)
         self.set_row(vertex, r)
 
-    def neighbors(self, vertex: VT) -> list[VT]:
+    def neighbors(self, vertex: VT) -> Collection[VT]:
         """Returns all neighboring vertices of the given vertex."""
         vs: set[VT] = set()
         for e in self.incident_edges(vertex):
@@ -1286,7 +1285,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return result
 
-    def __deepcopy__(self: Tvar, memo: dict[int, Tvar]) -> Tvar:
+    def __deepcopy__(self, memo: dict[int, Self]) -> Self:
         """Custom deepcopy implementation to ensure variable registry is properly handled
         while using Python's default deepcopy behavior."""
         cls = self.__class__

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -1285,7 +1285,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return result
 
-    def __deepcopy__(self, memo: dict[int, Self]) -> Self:
+    def __deepcopy__(self, memo: dict[int, Any]) -> Self:
         """Custom deepcopy implementation to ensure variable registry is properly handled
         while using Python's default deepcopy behavior."""
         cls = self.__class__

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -15,28 +15,32 @@
 # limitations under the License.
 
 from __future__ import annotations
-import math
+
 import copy
+import math
+from collections import Counter
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from fractions import Fraction
-from typing import TYPE_CHECKING, Collection, Counter, Generic, Optional, TypeVar, Any, Sequence
-from typing import Mapping, Iterable, Callable, ClassVar, Literal
-from typing_extensions import Self
+from typing import (TYPE_CHECKING, Any, ClassVar, Generic, Literal, Optional,
+                    TypeVar)
 
 import numpy as np
 
-from ..symbolic import Poly, VarRegistry, Var
-from ..utils import EdgeType, VertexType, toggle_edge, vertex_is_zx, get_z_box_label, set_z_box_label, get_h_box_label, set_h_box_label, hbox_has_complex_label
-from ..utils import FloatInt, FractionLike, assert_phase_real
-from .scalar import simplify_poly
-from ..tensor import tensorfy, tensor_to_matrix
+from pyzx.symbolic import Poly, Var, VarRegistry
+from pyzx.tensor import tensor_to_matrix, tensorfy
+from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                        assert_phase_real, get_h_box_label, get_z_box_label,
+                        hbox_has_complex_label, set_h_box_label,
+                        set_z_box_label, toggle_edge, vertex_is_zx)
 
-from .scalar import Scalar
+from .scalar import Scalar, simplify_poly
 
 if TYPE_CHECKING:
-    from .. import simplify
+    from pyzx import simplify
 
 
 MT = TypeVar("MT", bound="DocstringMeta") # Used for properly typing the metaclass
+Tvar = TypeVar("Tvar", bound="BaseGraph")
 
 class DocstringMeta(type):
     """Metaclass that allows docstring 'inheritance'."""
@@ -54,8 +58,8 @@ class DocstringMeta(type):
                         pass
         return new_class
 
-def pack_indices(lst: list[FloatInt]) -> Mapping[FloatInt,int]:
-    d: dict[FloatInt,int] = dict()
+def pack_indices(lst: list[FloatInt]) -> Mapping[FloatInt, int]:
+    d: dict[FloatInt, int] = dict()
     if len(lst) == 0: return d
     list.sort(lst)
     i: int = 0
@@ -94,22 +98,22 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         # self.outputs: list[VT] = []
         #Data necessary for phase tracking for phase teleportation
         self.track_phases: bool = False
-        self.phase_index : dict[VT,int] = dict() # {vertex:index tracking its phase for phase teleportation}
+        self.phase_index : dict[VT, int] = dict() # {vertex:index tracking its phase for phase teleportation}
         self.phase_master: Optional['simplify.Simplifier'] = None
-        self.phase_mult: dict[int,Literal[1,-1]] = dict()
+        self.phase_mult: dict[int, Literal[1,-1]] = dict()
         self.max_phase_index: int = -1
 
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
         self.merge_vdata: Callable[[VT, VT], None] | None = None
-        self.variable_types: dict[str,bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
+        self.variable_types: dict[str, bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
         self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
     # MANDATORY OVERRIDES {{{
 
     # All backends should override these methods
 
-    def clone(self) -> BaseGraph[VT,ET]:
+    def clone(self) -> BaseGraph[VT, ET]:
         """
         This method should return an identical copy of the graph, without any relabeling.
 
@@ -145,7 +149,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         which requires vertices to preserve their index."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_edge(self, edge_pair: tuple[VT,VT], edgetype: EdgeType = EdgeType.SIMPLE) -> ET:
+    def add_edge(self, edge_pair: tuple[VT, VT], edgetype: EdgeType = EdgeType.SIMPLE) -> ET:
         """Adds a single edge of the given type and return its id"""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -237,7 +241,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         Used e.g. in making a copy of the graph in a backend-independent way."""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
 
-    def vdata(self, vertex: VT, key: str, default: Any=None) -> Any:
+    def vdata(self, vertex: VT, key: str, default: Any = None) -> Any:
         """Returns the data value of the given vertex associated to the key.
         If this key has no value associated with it, it returns the default value."""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
@@ -254,7 +258,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns an iterable of the edge data key names."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def edata(self, edge: ET, key: str, default: Any=None) -> Any:
+    def edata(self, edge: ET, key: str, default: Any = None) -> Any:
         """Returns the data value of the given edge associated to the key.
         If this key has no value associated with it, it returns the default value."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
@@ -277,7 +281,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns the set of vertices connected to a ground."""
         return set(v for v in self.vertices() if self.is_ground(v))
 
-    def set_ground(self, vertex: VT, flag: bool=True) -> None:
+    def set_ground(self, vertex: VT, flag: bool = True) -> None:
         """Connect or disconnect the vertex to a ground."""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
 
@@ -303,7 +307,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns a mapping of vertices to their types."""
         return { v: self.type(v) for v in self.vertices() }
 
-    def qubits(self) -> Mapping[VT,FloatInt]:
+    def qubits(self) -> Mapping[VT, FloatInt]:
         """Returns a mapping of vertices to their qubit index."""
         return { v: self.qubit(v) for v in self.vertices() }
 
@@ -356,7 +360,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             return matched
         raise ValueError(f"No edge of type {et} between {s} and {t}")
 
-    def connected(self,v1: VT, v2: VT) -> bool:
+    def connected(self, v1: VT, v2: VT) -> bool:
         """Returns whether vertices v1 and v2 share an edge."""
         for e in self.incident_edges(v1):
             if v2 in self.edge_st(e):
@@ -396,7 +400,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             self.phase_mult[self.max_phase_index] = 1
         return v
 
-    def add_edges(self, edge_pairs: Iterable[tuple[VT,VT]], edgetype: EdgeType = EdgeType.SIMPLE) -> None:
+    def add_edges(self, edge_pairs: Iterable[tuple[VT, VT]], edgetype: EdgeType = EdgeType.SIMPLE) -> None:
         """Adds a list of edges to the graph."""
         for ep in edge_pairs:
             self.add_edge(ep, edgetype)
@@ -478,7 +482,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             Returns a string with some information regarding the degree distribution of the graph.
         """
         s = str(self) + "\n"
-        degrees: dict[int,int] = {}
+        degrees: dict[int, int] = {}
         for v in self.vertices():
             d = self.vertex_degree(v)
             if d in degrees: degrees[d] += 1
@@ -488,7 +492,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             s += "{:d}: {:d}\n".format(d,n)
         return s
 
-    def copy(self, adjoint: bool = False, backend: str | None = None) -> BaseGraph[VT,ET]:
+    def copy(self, adjoint: bool = False, backend: str | None = None) -> BaseGraph[VT, ET]:
         """Create a copy of the graph. If ``adjoint`` is set,
         the adjoint of the graph will be returned (inputs and outputs flipped, phases reversed).
         When ``backend`` is set, a copy of the graph with the given backend is produced.
@@ -505,7 +509,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             The copy will have consecutive vertex indices, even if the original
             graph did not.
         """
-        from .graph import Graph # imported here to prevent circularity
+        from .graph import Graph  # imported here to prevent circularity
         from .multigraph import Multigraph
         if (backend is None):
             backend = type(self).backend
@@ -564,12 +568,12 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return g
 
-    def adjoint(self) -> BaseGraph[VT,ET]:
+    def adjoint(self) -> BaseGraph[VT, ET]:
         """Returns a new graph equal to the adjoint of this graph."""
         return self.copy(adjoint=True)
 
 
-    def map_qubits(self, qubit_map: Mapping[int, tuple[float,float]]) -> None:
+    def map_qubits(self, qubit_map: Mapping[int, tuple[float, float]]) -> None:
         for v in self.vertices():
             q = self.qubit(v)
             r = self.row(v)
@@ -581,7 +585,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             self.set_qubit(v, qf)
             self.set_row(v, rf)
 
-    def compose(self, other: BaseGraph[VT,ET]) -> None:
+    def compose(self, other: BaseGraph[VT, ET]) -> None:
         """Inserts a graph after this one. The amount of qubits of the graphs must match.
         Also available by the operator `graph1 + graph2`"""
         other = other.copy()
@@ -590,7 +594,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         if len(outputs) != len(inputs):
             raise TypeError("Outputs of first graph must match inputs of second.")
 
-        plugs: list[tuple[VT,VT,EdgeType]] = []
+        plugs: list[tuple[VT, VT, EdgeType]] = []
         for k in range(len(outputs)):
             o = outputs[k]
             i = inputs[k]
@@ -614,7 +618,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         for v in outputs:
             self.remove_vertex(v)
 
-        vtab : dict[VT,VT] = dict()
+        vtab : dict[VT, VT] = dict()
         for v in other.vertices():
             if not v in inputs:
                 w = self.add_vertex(other.type(v),
@@ -637,7 +641,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             self.var_registry.set_type(name, other.var_registry.get_type(name))
         self.rebind_variables_to_registry()
 
-    def tensor(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def tensor(self, other: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         """Take the tensor product of two graphs. Places the second graph below the first one.
         Can also be called using the operator ``graph1 @ graph2``"""
         g = self.copy()
@@ -676,25 +680,25 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return g
 
-    def __iadd__(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def __iadd__(self, other: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         self.compose(other)
         return self
 
-    def __add__(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def __add__(self, other: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         g = self.copy()
         g += other
         return g
 
-    def __mul__(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def __mul__(self, other: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         """Compose two diagrams, in formula order. That is, g * h produces 'g AFTER h'."""
         g = other.copy()
         g.compose(self)
         return g
 
-    def __matmul__(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def __matmul__(self, other: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         return self.tensor(other)
 
-    def merge(self, other: BaseGraph[VT,ET]) -> tuple[list[VT],list[ET]]:
+    def merge(self, other: BaseGraph[VT, ET]) -> tuple[list[VT],list[ET]]:
         """Merges this graph with the other graph in-place.
         Returns (list-of-vertices, list-of-edges) corresponding to
         the id's of the vertices and edges of the other graph."""
@@ -721,9 +725,9 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.rebind_variables_to_registry()
         return (list(vert_map.values()),edges)
 
-    def subgraph_from_vertices(self,verts: list[VT]) -> BaseGraph[VT,ET]:
+    def subgraph_from_vertices(self, verts: list[VT]) -> BaseGraph[VT, ET]:
         """Returns the subgraph consisting of the specified vertices."""
-        from .graph import Graph # imported here to prevent circularity
+        from .graph import Graph  # imported here to prevent circularity
         g = Graph(backend=type(self).backend)
         g.set_auto_simplify(self.get_auto_simplify())
         ty = self.types()
@@ -843,20 +847,20 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         from .jsonparser import to_graphml
         return to_graphml(self)
 
-    def to_tikz(self,draw_scalar: bool=False) -> str:
+    def to_tikz(self, draw_scalar: bool = False) -> str:
         """Returns a Tikz representation of the graph."""
         from ..tikz import to_tikz
-        return to_tikz(self,draw_scalar)
+        return to_tikz(self, draw_scalar)
 
     @classmethod
-    def from_json(cls, js: str | dict[str,Any]) -> BaseGraph[VT,ET]:
+    def from_json(cls, js: str | dict[str, Any]) -> BaseGraph[VT, ET]:
         """Converts the given .qgraph json string into a Graph.
         Works with the output of :meth:`to_json`."""
         from .jsonparser import json_to_graph
         return json_to_graph(js)
 
     @classmethod
-    def from_tikz(cls, tikz: str, warn_overlap: bool = True, fuse_overlap: bool = True, ignore_nonzx: bool = False) -> BaseGraph[VT,ET]:
+    def from_tikz(cls, tikz: str, warn_overlap: bool = True, fuse_overlap: bool = True, ignore_nonzx: bool = False) -> BaseGraph[VT, ET]:
         """Converts a tikz diagram into a pyzx Graph.
     The tikz diagram is assumed to be one generated by Tikzit,
     and hence should have a nodelayer and a edgelayer..
@@ -1045,16 +1049,16 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         self.pack_circuit_rows()
 
-    def translate(self, x: FloatInt, y: FloatInt) -> BaseGraph[VT,ET]:
+    def translate(self, x: FloatInt, y: FloatInt) -> BaseGraph[VT, ET]:
         g = self.copy()
         for v in g.vertices():
             g.set_row(v, g.row(v)+x)
-            g.set_qubit(v,g.qubit(v)+y)
+            g.set_qubit(v, g.qubit(v)+y)
         return g
 
 
 
-    def add_edge_table(self, etab: Mapping[tuple[VT,VT], list[int]]) -> None:
+    def add_edge_table(self, etab: Mapping[tuple[VT, VT], list[int]]) -> None:
         """Takes a dictionary mapping (source,target) --> (#edges, #h-edges) specifying that
         #edges regular edges must be added between source and target and $h-edges Hadamard edges.
         The method selectively adds or removes edges to produce that ZX diagram which would
@@ -1282,7 +1286,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return result
 
-    def __deepcopy__(self, memo: dict[int, Self]) -> Self:
+    def __deepcopy__(self: Tvar, memo: dict[int, Tvar]) -> Tvar:
         """Custom deepcopy implementation to ensure variable registry is properly handled
         while using Python's default deepcopy behavior."""
         cls = self.__class__

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -169,7 +169,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns the amount of edges in the graph"""
         return len(list(self.edges(s, t)))
 
-    def vertices(self) -> Iterable[VT]:
+    def vertices(self) -> list[VT]:
         """Iterator over all the vertices."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 

--- a/pyzx/graph/diff.py
+++ b/pyzx/graph/diff.py
@@ -20,9 +20,8 @@ from collections import Counter
 from collections.abc import Callable
 from typing import Any, Generic
 
-from pyzx.symbolic import VarRegistry
-from pyzx.utils import EdgeType, FloatInt, FractionLike, VertexType, phase_to_s
-
+from ..symbolic import VarRegistry
+from ..utils import EdgeType, FloatInt, FractionLike, VertexType, phase_to_s
 from .base import ET, VT, BaseGraph
 from .graph_s import GraphS
 from .jsonparser import string_to_phase

--- a/pyzx/graph/diff.py
+++ b/pyzx/graph/diff.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -17,32 +17,35 @@
 import copy
 import json
 from collections import Counter
-from typing import Any, Callable, Generic, Optional, List, Dict, Tuple
+from collections.abc import Callable
+from typing import Any, Generic
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, phase_to_s
-from .base import BaseGraph, VT, ET
+from pyzx.symbolic import VarRegistry
+from pyzx.utils import EdgeType, FloatInt, FractionLike, VertexType, phase_to_s
+
+from .base import ET, VT, BaseGraph
 from .graph_s import GraphS
 from .jsonparser import string_to_phase
-from ..symbolic import VarRegistry
+
 
 class GraphDiff(Generic[VT, ET]):
-    removed_verts: List[VT]
-    new_verts: List[VT]
-    removed_edges: List[ET]
-    new_edges: List[Tuple[Tuple[VT,VT],EdgeType]]
-    changed_vertex_types: Dict[VT,VertexType]
-    changed_edge_types: Dict[ET, EdgeType]
-    changed_phases: Dict[VT, FractionLike]
-    changed_pos: Dict[VT, Tuple[FloatInt,FloatInt]]
-    changed_vdata: Dict[VT, Any]
-    changed_edata: Dict[ET, Any]
-    variable_types: Dict[str,bool]
+    removed_verts: list[VT]
+    new_verts: list[VT]
+    removed_edges: list[ET]
+    new_edges: list[tuple[tuple[VT, VT],EdgeType]]
+    changed_vertex_types: dict[VT,VertexType]
+    changed_edge_types: dict[ET, EdgeType]
+    changed_phases: dict[VT, FractionLike]
+    changed_pos: dict[VT, tuple[FloatInt, FloatInt]]
+    changed_vdata: dict[VT, Any]
+    changed_edata: dict[ET, Any]
+    variable_types: dict[str, bool]
     var_registry: VarRegistry
 
-    def __init__(self, g1: BaseGraph[VT,ET], g2: BaseGraph[VT,ET]) -> None:
+    def __init__(self, g1: BaseGraph[VT, ET], g2: BaseGraph[VT, ET]) -> None:
         self.calculate_diff(g1,g2)
 
-    def calculate_diff(self, g1: BaseGraph[VT,ET], g2: BaseGraph[VT,ET]) -> None:
+    def calculate_diff(self, g1: BaseGraph[VT, ET], g2: BaseGraph[VT, ET]) -> None:
         self.changed_vertex_types = {}
         self.changed_edge_types = {}
         self.changed_phases = {}
@@ -111,7 +114,7 @@ class GraphDiff(Generic[VT, ET]):
                 if d2:
                     self.changed_edata[e] = d2
 
-    def apply_diff(self,g: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
+    def apply_diff(self,g: BaseGraph[VT, ET]) -> BaseGraph[VT, ET]:
         g = copy.deepcopy(g)
         g.remove_edges(self.removed_edges)
         g.remove_vertices(self.removed_verts)
@@ -156,7 +159,7 @@ class GraphDiff(Generic[VT, ET]):
         g.rebind_variables_to_registry()
         return g
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         changed_edge_types_str_dict = {}
         for key, value in self.changed_edge_types.items():
             changed_edge_types_str_dict[f"{key[0]},{key[1]}"] = value # type: ignore
@@ -184,7 +187,7 @@ class GraphDiff(Generic[VT, ET]):
     @staticmethod
     def from_json(json_str: str) -> "GraphDiff":
         d = json.loads(json_str)
-        gd = GraphDiff(GraphS(),GraphS())
+        gd = GraphDiff(GraphS(), GraphS())
         gd.var_registry = VarRegistry()
         for name, is_bool in d["variable_types"].items():
             gd.var_registry.set_type(name, is_bool)
@@ -203,5 +206,5 @@ class GraphDiff(Generic[VT, ET]):
             gd.changed_edata = {}
         return gd
 
-def map_dict_keys(d: Dict[str, Any], f: Callable[[str], Any]) -> Dict[Any, Any]:
+def map_dict_keys(d: dict[str, Any], f: Callable[[str], Any]) -> dict[Any, Any]:
     return {f(k): v for k, v in d.items()}

--- a/pyzx/graph/graph.py
+++ b/pyzx/graph/graph.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,22 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 from .base import BaseGraph
 from .graph_s import GraphS
 from .multigraph import Multigraph
 
 try:
-	import quizx # type: ignore
+	import quizx  # type: ignore
 except ImportError:
 	quizx = None
 
 backends = { 'simple': True, 'multigraph': True, 'quizx-vec': False if quizx is None else True }
 
-def Graph(backend:Optional[str]=None) -> BaseGraph:
-	"""Returns an instance of an implementation of :class:`~pyzx.graph.base.BaseGraph`. 
-	By default :class:`~pyzx.graph.graph_s.GraphS` is used. 
+def Graph(backend: str | None = None) -> BaseGraph:
+	"""Returns an instance of an implementation of :class:`~pyzx.graph.base.BaseGraph`.
+	By default :class:`~pyzx.graph.graph_s.GraphS` is used.
 	Currently ``backend`` is allowed to be `simple` (for the default),
 	or 'graph_tool' and 'igraph'.
 	This method is the preferred way to instantiate a ZX-diagram in PyZX.
@@ -45,7 +43,7 @@ def Graph(backend:Optional[str]=None) -> BaseGraph:
 		raise KeyError("Unavailable backend '{}'".format(backend))
 	if backend == 'simple': return GraphS()
 	if backend == 'multigraph': return Multigraph()
-	if backend == 'graph_tool': 
+	if backend == 'graph_tool':
 		return GraphGT()
 	if backend == 'igraph': return GraphIG()
 	if backend == 'quizx-vec': return quizx.VecGraph()
@@ -57,13 +55,15 @@ Graph.load = GraphS.load # type: ignore
 
 try:
 	import graph_tool.all as gt
+
 	from .graph_gt import GraphGT
 	backends['graph_tool'] = gt
 except ImportError:
 	pass
 try:
 	import igraph as ig
+
 	from .graph_ig import GraphIG
-	backends['igraph'] = ig 
+	backends['igraph'] = ig
 except ImportError:
 	pass

--- a/pyzx/graph/graph_gt.py
+++ b/pyzx/graph/graph_gt.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# mypy: disable-error-code="no-untyped-def"
 
 import graph_tool.all as gt
 

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimisation using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# mypy: disable-error-code="no-untyped-def"
+
 try:
 	import igraph as ig
 except ImportError:
@@ -26,7 +28,7 @@ from .base import BaseGraph, VertexType, EdgeType
 from ..utils import assert_phase_real, normalize_phase
 
 class GraphIG(BaseGraph):
-	"""Implementation of :class:`~graph.base.BaseGraph` using ``python-igraph`` 
+	"""Implementation of :class:`~graph.base.BaseGraph` using ``python-igraph``
 	as its backend"""
 	backend = 'igraph'
 	graph: "ig.Graph"
@@ -49,7 +51,7 @@ class GraphIG(BaseGraph):
 	def vindex(self):
 		return self.num_vertices()
 
-	def depth(self): 
+	def depth(self):
 		self._maxr = max(self._rindex.values())
 		return self._maxr
 	def qubit_count(self): return self._maxq + 1

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -14,12 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Generator, Iterable
 from fractions import Fraction
-from typing import Generator, Iterable, Any, Optional
+from typing import Any
+
+from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                        assert_phase_real, get_z_box_label, normalize_phase,
+                        set_z_box_label, vertex_is_z_like, vertex_is_zx_like)
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real, normalize_phase
 
 class GraphS(BaseGraph[int, tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
@@ -29,21 +33,21 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
     #can be found in base.BaseGraph
     def __init__(self) -> None:
         BaseGraph.__init__(self)
-        self.graph: dict[int,dict[int,EdgeType]]   = dict()
-        self._vindex: int                               = 0
-        self.nedges: int                                = 0
-        self.ty: dict[int,VertexType]              = dict()
-        self._phase: dict[int, FractionLike]            = dict()
-        self._qindex: dict[int, FloatInt]               = dict()
-        self._maxq: FloatInt                            = -1
-        self._rindex: dict[int, FloatInt]               = dict()
-        self._maxr: FloatInt                            = -1
+        self.graph: dict[int, dict[int, EdgeType]] = {}
+        self._vindex: int = 0
+        self.nedges: int = 0
+        self.ty: dict[int, VertexType] = {}
+        self._phase: dict[int, FractionLike] = {}
+        self._qindex: dict[int, FloatInt] = {}
+        self._maxq: FloatInt = -1
+        self._rindex: dict[int, FloatInt] = {}
+        self._maxr: FloatInt = -1
         self._grounds: set[int] = set()
 
-        self._vdata: dict[int,Any]                      = dict()
+        self._vdata: dict[int,Any] = {}
         self._edata: dict[tuple[int,int],Any] = dict()
-        self._inputs: tuple[int, ...]                   = tuple()
-        self._outputs: tuple[int, ...]                  = tuple()
+        self._inputs: tuple[int, ...] = tuple()
+        self._outputs: tuple[int, ...] = tuple()
 
     def clone(self) -> 'GraphS':
         cpy = GraphS()
@@ -288,7 +292,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
                         if v1 > v0:
                             yield (v0,v1)
 
-    def edge(self, s: int, t: int, et: Optional[EdgeType] = None) -> tuple[int, int]:
+    def edge(self, s: int, t: int, et: EdgeType | None = None) -> tuple[int, int]:
         """Return the canonical pair ``(min(s, t), max(s, t))`` whether or not the
         edge exists; this supports the ``g.add_edge(g.edge(v, w), ...)`` pattern.
         ``et`` is accepted for consistency with :meth:`BaseGraph.edge` but ignored,

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from fractions import Fraction
 from typing import Any
 
-from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
-                        assert_phase_real, get_z_box_label, normalize_phase,
-                        set_z_box_label, vertex_is_z_like, vertex_is_zx_like)
-
+from ..utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                     assert_phase_real, get_z_box_label, normalize_phase,
+                     set_z_box_label, vertex_is_z_like, vertex_is_zx_like)
 from .base import BaseGraph
 
 
@@ -44,8 +43,8 @@ class GraphS(BaseGraph[int, tuple[int, int]]):
         self._maxr: FloatInt = -1
         self._grounds: set[int] = set()
 
-        self._vdata: dict[int,Any] = {}
-        self._edata: dict[tuple[int,int],Any] = dict()
+        self._vdata: dict[int, Any] = {}
+        self._edata: dict[tuple[int,int], Any] = {}
         self._inputs: tuple[int, ...] = tuple()
         self._outputs: tuple[int, ...] = tuple()
 
@@ -247,8 +246,8 @@ class GraphS(BaseGraph[int, tuple[int, int]]):
         else:
             return len(list(self.edges()))
 
-    def vertices(self) -> list[int]:
-        return list(self.graph.keys())
+    def vertices(self) -> Collection[int]:
+        return self.graph.keys()
 
     def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Iterator[int]:
         """Returns all vertices with index between start and end

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -247,8 +247,8 @@ class GraphS(BaseGraph[int, tuple[int, int]]):
         else:
             return len(list(self.edges()))
 
-    def vertices(self) -> Iterator[int]:
-        return iter(self.graph.keys())
+    def vertices(self) -> list[int]:
+        return list(self.graph.keys())
 
     def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Iterator[int]:
         """Returns all vertices with index between start and end

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Generator, Iterable
+from collections.abc import Iterable, Iterator
 from fractions import Fraction
 from typing import Any
 
@@ -25,7 +25,7 @@ from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
 from .base import BaseGraph
 
 
-class GraphS(BaseGraph[int, tuple[int,int]]):
+class GraphS(BaseGraph[int, tuple[int, int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
     backend = 'simple'
 
@@ -247,10 +247,10 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
         else:
             return len(list(self.edges()))
 
-    def vertices(self) -> Iterable[int]:
-        return self.graph.keys()
+    def vertices(self) -> Iterator[int]:
+        return iter(self.graph.keys())
 
-    def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Generator[int, None, None]:
+    def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Iterator[int]:
         """Returns all vertices with index between start and end
         that only have neighbours whose indices are between start and end"""
         for v in self.graph.keys():
@@ -258,7 +258,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
             if all(start<v2<end for v2 in self.graph[v]):
                 yield v
 
-    def edges(self, s: int | None = None, t: int | None = None) -> Generator[tuple[int, int], None, None]:
+    def edges(self, s: int | None = None, t: int | None = None) -> Iterator[tuple[int, int]]:
         if s is not None and t is not None:
             if self.connected(s, t):
                 yield (s,t) if s < t else (t,s)
@@ -270,7 +270,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
                 for v1 in adj:
                     if v1 > v0: yield (v0,v1)
 
-    def edges_in_range(self, start: FloatInt, end: FloatInt, safe: bool = False) -> Generator[tuple[int, int], None, None]:
+    def edges_in_range(self, start: FloatInt, end: FloatInt, safe: bool = False) -> Iterator[tuple[int, int]]:
         """like self.edges, but only returns edges that belong to vertices
         that are only directly connected to other vertices with
         index between start and end.

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -16,21 +16,23 @@
 
 __all__ = ['string_to_phase','to_graphml']
 
+import ast
 import json
 import re
-import ast
 import warnings
 from fractions import Fraction
-from typing import Any, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
+
 from typing_extensions import deprecated
 
 from pyzx.graph.multigraph import Multigraph
+from pyzx.symbolic import Poly, VarRegistry, new_var, parse
+from pyzx.utils import EdgeType, VertexType, phase_to_s
 
-from ..utils import EdgeType, VertexType, phase_to_s
+from .base import ET, VT, BaseGraph
 from .graph import Graph
 from .scalar import Scalar, simplify_poly
-from .base import BaseGraph, VT, ET
-from ..symbolic import parse, Poly, new_var, VarRegistry
+
 if TYPE_CHECKING:
     from .diff import GraphDiff
 
@@ -185,7 +187,7 @@ def json_to_graph_old(js: str | dict[str, Any], backend: str | None = None) -> B
 
     return g
 
-def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[str, Any]:
+def graph_to_dict(g: BaseGraph[VT, ET], include_scalar: bool = True) -> dict[str, Any]:
     """Converts a PyZX graph into Python dict for JSON output.
     If include_scalar is set to True (the default), then this includes the value
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
@@ -251,7 +253,7 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[str, A
 
 
 @deprecated("graph_to_dict_old is deprecated, use graph_to_dict instead")
-def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[str, Any]:
+def graph_to_dict_old(g: BaseGraph[VT, ET], include_scalar: bool = True) -> dict[str, Any]:
     """Deprecated: Use :func:`graph_to_dict` instead.
 
     Converts a PyZX graph into Python dict for JSON output that is compatible with the Quantomatic format.
@@ -349,7 +351,7 @@ def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[st
         else:
             raise TypeError("Edge of type 0")
 
-    d: dict[str,Any] = {
+    d: dict[str, Any] = {
         "wire_vertices": wire_vs,
         "node_vertices": node_vs,
         "undir_edges": edges,
@@ -360,7 +362,7 @@ def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[st
 
     return d
 
-def graph_to_json(g: BaseGraph[VT,ET], include_scalar: bool=True) -> str:
+def graph_to_json(g: BaseGraph[VT, ET], include_scalar: bool = True) -> str:
     """Converts a PyZX graph into JSON output compatible with Quantomatic.
     If include_scalar is set to True (the default), then this includes the value
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
@@ -436,7 +438,7 @@ def json_to_graph(js: str | dict[str, Any], backend: str | None = None) -> BaseG
         d = js
     return dict_to_graph(d, backend)
 
-def to_graphml(g: BaseGraph[VT,ET]) -> str:
+def to_graphml(g: BaseGraph[VT, ET]) -> str:
     gml = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns">
     <key attr.name="type" attr.type="int" for="node" id="type">

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -21,14 +21,13 @@ import json
 import re
 import warnings
 from fractions import Fraction
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import deprecated
 
-from pyzx.graph.multigraph import Multigraph
-from pyzx.symbolic import Poly, VarRegistry, new_var, parse
-from pyzx.utils import EdgeType, VertexType, phase_to_s
-
+from ..graph.multigraph import Multigraph
+from ..symbolic import Poly, VarRegistry, new_var, parse
+from ..utils import EdgeType, VertexType, phase_to_s
 from .base import ET, VT, BaseGraph
 from .graph import Graph
 from .scalar import Scalar, simplify_poly
@@ -37,7 +36,7 @@ if TYPE_CHECKING:
     from .diff import GraphDiff
 
 
-def string_to_phase(string: str, g: Union[BaseGraph, 'GraphDiff', None] = None) -> Fraction | Poly:
+def string_to_phase(string: str, g: 'BaseGraph | GraphDiff | None' = None) -> Fraction | Poly:
     if not string:
         return Fraction(0)
     try:

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -25,11 +25,11 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import deprecated
 
-from ..graph.multigraph import Multigraph
 from ..symbolic import Poly, VarRegistry, new_var, parse
 from ..utils import EdgeType, VertexType, phase_to_s
 from .base import ET, VT, BaseGraph
 from .graph import Graph
+from .multigraph import Multigraph
 from .scalar import Scalar, simplify_poly
 
 if TYPE_CHECKING:

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -16,12 +16,16 @@
 
 import itertools
 from collections import Counter
+from collections.abc import Iterable
 from fractions import Fraction
-from typing import Iterable, Any, Optional, cast
+from typing import Any, cast
+
+from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                        assert_phase_real, get_z_box_label, normalize_phase,
+                        set_z_box_label, vertex_is_zx_like)
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, set_z_box_label, get_z_box_label, assert_phase_real, normalize_phase
 
 class Edge:
     """A structure for storing the number of simple and number of Hadamard edges
@@ -30,7 +34,7 @@ class Edge:
     h: int
     w_io: int
 
-    def __init__(self, s: int=0, h: int=0, w_io: int=0):
+    def __init__(self, s: int = 0, h: int = 0, w_io: int = 0):
         self.s = s
         self.h = h
         self.w_io = w_io
@@ -58,7 +62,7 @@ class Edge:
         else: return self.w_io
 
 
-class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
+class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
     """Purely Pythonic multigraph implementation of :class:`~graph.base.BaseGraph`."""
     backend = 'multigraph'
 
@@ -66,22 +70,22 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     #can be found in base.BaseGraph
     def __init__(self) -> None:
         BaseGraph.__init__(self)
-        self.graph: dict[int,dict[int,Edge]]   = dict()
-        self._auto_simplify: bool                       = True
-        self._vindex: int                               = 0
-        self.nedges: int                                = 0
-        self.ty: dict[int,VertexType]                   = dict()
-        self._phase: dict[int, FractionLike]            = dict()
-        self._qindex: dict[int, FloatInt]               = dict()
-        self._maxq: FloatInt                            = -1
-        self._rindex: dict[int, FloatInt]               = dict()
-        self._maxr: FloatInt                            = -1
-        self._grounds: set[int]                         = set()
+        self.graph: dict[int, dict[int, Edge]] = {}
+        self._auto_simplify: bool = True
+        self._vindex: int = 0
+        self.nedges: int = 0
+        self.ty: dict[int, VertexType] = {}
+        self._phase: dict[int, FractionLike] = {}
+        self._qindex: dict[int, FloatInt] = {}
+        self._maxq: FloatInt = -1
+        self._rindex: dict[int, FloatInt] = {}
+        self._maxr: FloatInt = -1
+        self._grounds: set[int] = set()
 
-        self._vdata: dict[int,Any]                      = dict()
-        self._edata: dict[tuple[int, int, EdgeType], dict[str, Any]] = dict()
-        self._inputs: tuple[int, ...]                   = tuple()
-        self._outputs: tuple[int, ...]                  = tuple()
+        self._vdata: dict[int, Any] = {}
+        self._edata: dict[tuple[int, int, EdgeType], dict[str, Any]] = {}
+        self._inputs: tuple[int, ...] = tuple()
+        self._outputs: tuple[int, ... ] = tuple()
     
     
     def clone(self) -> 'Multigraph':
@@ -152,7 +156,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
 
     def add_vertices(self, amount: int) -> range:
         for i in range(self._vindex, self._vindex + amount):
-            self.graph[i] = dict()
+            self.graph[i] = {}
             self.ty[i] = VertexType.BOUNDARY
             self._phase[i] = 0
         self._vindex += amount
@@ -165,7 +169,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
         to preserve their index."""
         if v in self.graph: raise ValueError("Vertex with this index already exists")
         if v >= self._vindex: self._vindex = v+1
-        self.graph[v] = dict()
+        self.graph[v] = {}
         self.ty[v] = VertexType.BOUNDARY
         self._phase[v] = 0
 
@@ -348,7 +352,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     #                    if v1 > v0:
     #                        yield (v0,v1)
 
-    def edge(self, s: int, t: int, et: Optional[EdgeType] = None) -> tuple[int, int, EdgeType]:
+    def edge(self, s: int, t: int, et: EdgeType | None = None) -> tuple[int, int, EdgeType]:
         s, t = (s, t) if s < t else (t, s)
         adj = self.graph.get(s)
         if adj is None or t not in adj:
@@ -358,7 +362,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
             if e.get_edge_count(et):
                 return (s, t, et)
             raise ValueError(f"No edge of type {et} between {s} and {t}")
-        found: Optional[EdgeType] = None
+        found: EdgeType | None = None
         for ty in (EdgeType.SIMPLE, EdgeType.HADAMARD, EdgeType.W_IO):
             if e.get_edge_count(ty):
                 if found is not None:

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -16,7 +16,7 @@
 
 import itertools
 from collections import Counter
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from fractions import Fraction
 from typing import Any, cast
 
@@ -302,10 +302,10 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
         else:
             return self.nedges
 
-    def vertices(self) -> Iterable[int]:
-        return self.graph.keys()
+    def vertices(self) -> Iterator[int]:
+        return iter(self.graph.keys())
 
-    def vertices_in_range(self, start: int, end: int) -> Iterable[int]:
+    def vertices_in_range(self, start: int, end: int) -> Iterator[int]:
         """Returns all vertices with index between start and end
         that only have neighbours whose indices are between start and end"""
         for v in self.graph.keys():
@@ -313,7 +313,7 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
             if all(start<v2<end for v2 in self.graph[v]):
                 yield v
 
-    def edges(self, s: int | None = None, t: int | None = None) -> Iterable[tuple[int, int, EdgeType]]:
+    def edges(self, s: int | None = None, t: int | None = None) -> Iterator[tuple[int, int, EdgeType]]:
         if s is None:
             for v0,adj in self.graph.items():
                 for v1, e in adj.items():
@@ -384,8 +384,8 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
     def edge_st(self, edge: tuple[int, int, EdgeType]) -> tuple[int, int]:
         return (edge[0], edge[1])
 
-    def neighbors(self, vertex: int) -> Iterable[int]:
-        return self.graph[vertex].keys()
+    def neighbors(self, vertex: int) -> list[int]:
+        return list(self.graph[vertex].keys())
 
     def vertex_degree(self, vertex: int) -> int:
         d = 0

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -302,8 +302,8 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
         else:
             return self.nedges
 
-    def vertices(self) -> Iterator[int]:
-        return iter(self.graph.keys())
+    def vertices(self) -> list[int]:
+        return list(self.graph.keys())
 
     def vertices_in_range(self, start: int, end: int) -> Iterator[int]:
         """Returns all vertices with index between start and end

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -16,14 +16,13 @@
 
 import itertools
 from collections import Counter
-from collections.abc import Iterable, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from fractions import Fraction
 from typing import Any, cast
 
-from pyzx.utils import (EdgeType, FloatInt, FractionLike, VertexType,
-                        assert_phase_real, get_z_box_label, normalize_phase,
-                        set_z_box_label, vertex_is_zx_like)
-
+from ..utils import (EdgeType, FloatInt, FractionLike, VertexType,
+                     assert_phase_real, get_z_box_label, normalize_phase,
+                     set_z_box_label, vertex_is_zx_like)
 from .base import BaseGraph
 
 
@@ -302,8 +301,8 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
         else:
             return self.nedges
 
-    def vertices(self) -> list[int]:
-        return list(self.graph.keys())
+    def vertices(self) -> Collection[int]:
+        return self.graph.keys()
 
     def vertices_in_range(self, start: int, end: int) -> Iterator[int]:
         """Returns all vertices with index between start and end
@@ -384,8 +383,8 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
     def edge_st(self, edge: tuple[int, int, EdgeType]) -> tuple[int, int]:
         return (edge[0], edge[1])
 
-    def neighbors(self, vertex: int) -> list[int]:
-        return list(self.graph[vertex].keys())
+    def neighbors(self, vertex: int) -> Collection[int]:
+        return self.graph[vertex].keys()
 
     def vertex_degree(self, vertex: int) -> int:
         d = 0

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -84,9 +84,9 @@ class Multigraph(BaseGraph[int, tuple[int, int, EdgeType]]):
         self._vdata: dict[int, Any] = {}
         self._edata: dict[tuple[int, int, EdgeType], dict[str, Any]] = {}
         self._inputs: tuple[int, ...] = tuple()
-        self._outputs: tuple[int, ... ] = tuple()
-    
-    
+        self._outputs: tuple[int, ...] = tuple()
+
+
     def clone(self) -> 'Multigraph':
         cpy = Multigraph()
         for v, d in self.graph.items():

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -16,22 +16,23 @@
 
 """This file contains the Scalar class used to represent a global scalar in a Graph."""
 
-import math
 import cmath
 import copy
-from fractions import Fraction
-from typing import Any, Dict, List, Mapping, Set, Union
 import json
+import math
+from collections.abc import Mapping
+from fractions import Fraction
+from typing import Any
 
-from ..utils import FractionLike, phase_is_pauli, phase_is_clifford
-from ..symbolic import Poly, Var
+from pyzx.symbolic import Poly, Var
+from pyzx.utils import FractionLike, phase_is_clifford, phase_is_pauli
 
 __all__ = ['Scalar']
 
-def cexp(val) -> complex:
+def cexp(val: complex | Fraction) -> complex:
     return cmath.exp(1j*math.pi*val)
 
-def simplify_poly(p: Poly) -> Union[int, complex, Fraction, Poly]:
+def simplify_poly(p: Poly) -> complex | Fraction | Poly:
     """Unwrap a constant Poly to its scalar value, or return the Poly as-is.
 
     Float and purely-real complex values are normalized to Fraction so
@@ -70,13 +71,13 @@ unicode_fractions = {
     Fraction(3,4): '¾',
 }
 
-class Scalar(object):
+class Scalar:
     """Represents a global scalar for a Graph instance."""
     def __init__(self) -> None:
         self.power2: int = 0 # Stores power of square root of two
         self.phase: FractionLike = Fraction(0) # Stores complex phase of the number
-        self.phasenodes: List[FractionLike] = [] # Stores list of legless spiders, by their phases.
-        self.sum_of_phases: Dict[FractionLike, int] = {} # Represents the term (c1*exp(i*phase1) + ... + cn*exp(i*phaseN)). The dictionary maps phase -> coefficient.
+        self.phasenodes: list[FractionLike] = [] # Stores list of legless spiders, by their phases.
+        self.sum_of_phases: dict[FractionLike, int] = {} # Represents the term (c1*exp(i*phase1) + ... + cn*exp(i*phaseN)). The dictionary maps phase -> coefficient.
         self.floatfactor: complex = 1.0
         self.is_unknown: bool = False # Whether this represents an unknown scalar value
         self.is_zero: bool = False
@@ -152,9 +153,9 @@ class Scalar(object):
         """Returns a new Scalar equal to the complex conjugate"""
         return self.copy(conjugate=True)
 
-    def free_vars(self) -> Set[Var]:
+    def free_vars(self) -> set[Var]:
         """Return all symbolic variables appearing in this scalar."""
-        result: Set[Var] = set()
+        result: set[Var] = set()
         if isinstance(self.phase, Poly):
             result.update(self.phase.free_vars())
         for node in self.phasenodes:
@@ -165,7 +166,7 @@ class Scalar(object):
                 result.update(phase.free_vars())
         return result
 
-    def substitute_variables(self, var_map: Mapping[Var, Union[float, complex, Fraction, Poly]]) -> 'Scalar':
+    def substitute_variables(self, var_map: Mapping[Var, float | complex | Fraction | Poly]) -> 'Scalar':
         """Substitute values for symbolic variables in the scalar.
 
         Args:
@@ -310,7 +311,7 @@ class Scalar(object):
             s = "1"
         return s
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = {"power2": self.power2, "phase": str(self.phase)}
         if abs(self.floatfactor - 1) > 0.00001:
             d["floatfactor"] =  str(self.floatfactor)
@@ -328,7 +329,7 @@ class Scalar(object):
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, s: Union[str,Dict[str,Any]]) -> 'Scalar':
+    def from_json(cls, s: str | dict[str, Any]) -> 'Scalar':
         from .jsonparser import string_to_phase
 
         if isinstance(s, str):
@@ -353,7 +354,7 @@ class Scalar(object):
     def set_unknown(self) -> None:
         self.is_unknown = True
 
-    def add_power(self, n) -> None:
+    def add_power(self, n: int) -> None:
         """Adds a factor of sqrt(2)^n to the scalar."""
         self.power2 += n
 
@@ -375,10 +376,10 @@ class Scalar(object):
             self.is_zero = True
         self.floatfactor *= f
 
-    def multiply_sum_of_phases(self, phases: Dict[FractionLike,int]) -> None:
+    def multiply_sum_of_phases(self, phases: dict[FractionLike, int]) -> None:
         """Adds a sum of phases to the scalar. The input is a dictionary mapping
         phase -> coefficient in the sum."""
-        new_sum_of_phases: Dict[FractionLike, int] = {}
+        new_sum_of_phases: dict[FractionLike, int] = {}
         # Use the distributive law: (a*e^ip1)(b*e^ip2) = (a*b)*e^i(p1+p2)
         if not self.sum_of_phases:
             self.sum_of_phases = {0:1}

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -211,6 +211,7 @@ class Scalar:
 
     def to_number(self) -> complex:
         if self.is_zero: return 0
+        
         val = cexp(self.phase)
         for node in self.phasenodes: # Node should be a Fraction
             val *= 1+cexp(node)

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -24,16 +24,13 @@ from collections.abc import Mapping
 from fractions import Fraction
 from typing import Any
 
-from pyzx.symbolic import Poly, Var
-from pyzx.utils import FractionLike, phase_is_clifford, phase_is_pauli
+from ..symbolic import Poly, Var
+from ..utils import FractionLike, phase_is_clifford, phase_is_pauli
 
 __all__ = ['Scalar']
 
-def cexp(val: Fraction | complex) -> complex:
-    """Compute the complex exponential of a value."""
-    return cmath.exp(1j*math.pi*val)
 
-def cexp_unsafe(val: Fraction | complex | Poly) -> complex:
+def cexp(val: Fraction | complex | Poly) -> complex:
     """Compute the complex exponential of a value or scalar polynomial. Raises an error for polynomials with free variables."""
     if isinstance(val, Poly):
         val = simplify_poly(val)
@@ -44,7 +41,7 @@ def cexp_unsafe(val: Fraction | complex | Poly) -> complex:
 
     return cmath.exp(1j*math.pi*val)
 
-def simplify_poly(p: Poly) -> complex | Fraction | Poly:
+def simplify_poly(p: Poly) -> int | complex | Fraction | Poly:
     """Unwrap a constant Poly to its scalar value, or return the Poly as-is.
 
     Float and purely-real complex values are normalized to Fraction so
@@ -223,13 +220,13 @@ class Scalar:
 
     def to_number(self) -> complex:
         if self.is_zero: return 0
-        
-        val = cexp_unsafe(self.phase)
+
+        val = cexp(self.phase)
         for node in self.phasenodes: # Node should be a Fraction
-            val *= 1+cexp_unsafe(node)
+            val *= 1+cexp(node)
         sum_of_phases_val = 0j
         for phase, coeff in self.sum_of_phases.items():
-            sum_of_phases_val += coeff * cexp_unsafe(phase)
+            sum_of_phases_val += coeff * cexp(phase)
         if sum_of_phases_val != 0:
             val *= sum_of_phases_val
         val *= math.sqrt(2)**self.power2
@@ -241,7 +238,7 @@ class Scalar:
         elif self.is_unknown: return "Unknown"
         f = self.floatfactor
         for node in self.phasenodes:
-            f *= 1+cexp_unsafe(node)
+            f *= 1+cexp(node)
         if self.phase == 1:
             f *= -1
 
@@ -282,7 +279,7 @@ class Scalar:
         elif self.is_unknown: return "Unknown"
         f = self.floatfactor
         for node in self.phasenodes:
-            f *= 1+cexp_unsafe(node)
+            f *= 1+cexp(node)
         s = ""
         phase = self.phase
         if not isinstance(phase, Poly):

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -29,7 +29,19 @@ from pyzx.utils import FractionLike, phase_is_clifford, phase_is_pauli
 
 __all__ = ['Scalar']
 
-def cexp(val: complex | Fraction) -> complex:
+def cexp(val: Fraction | complex) -> complex:
+    """Compute the complex exponential of a value."""
+    return cmath.exp(1j*math.pi*val)
+
+def cexp_unsafe(val: Fraction | complex | Poly) -> complex:
+    """Compute the complex exponential of a value or scalar polynomial. Raises an error for polynomials with free variables."""
+    if isinstance(val, Poly):
+        val = simplify_poly(val)
+
+    # unwrapping failed because the polynomial was non-constant
+    if isinstance(val, Poly):
+        raise ValueError("Cannot convert symbolic value to number")
+
     return cmath.exp(1j*math.pi*val)
 
 def simplify_poly(p: Poly) -> complex | Fraction | Poly:
@@ -212,12 +224,12 @@ class Scalar:
     def to_number(self) -> complex:
         if self.is_zero: return 0
         
-        val = cexp(self.phase)
+        val = cexp_unsafe(self.phase)
         for node in self.phasenodes: # Node should be a Fraction
-            val *= 1+cexp(node)
+            val *= 1+cexp_unsafe(node)
         sum_of_phases_val = 0j
         for phase, coeff in self.sum_of_phases.items():
-            sum_of_phases_val += coeff * cexp(phase)
+            sum_of_phases_val += coeff * cexp_unsafe(phase)
         if sum_of_phases_val != 0:
             val *= sum_of_phases_val
         val *= math.sqrt(2)**self.power2
@@ -229,7 +241,7 @@ class Scalar:
         elif self.is_unknown: return "Unknown"
         f = self.floatfactor
         for node in self.phasenodes:
-            f *= 1+cexp(node)
+            f *= 1+cexp_unsafe(node)
         if self.phase == 1:
             f *= -1
 
@@ -270,7 +282,7 @@ class Scalar:
         elif self.is_unknown: return "Unknown"
         f = self.floatfactor
         for node in self.phasenodes:
-            f *= 1+cexp(node)
+            f *= 1+cexp_unsafe(node)
         s = ""
         phase = self.phase
         if not isinstance(phase, Poly):


### PR DESCRIPTION
Follow-up to #461 and #473 which fills in the remaining missing type annotations and enables the mypy setting to require type annotations on all functions. The deprecated `graph_ig.py` and `graph_gt.py` are excluded because the classes aren't even possible to instantiate (the constructor raises an exception). Some additional cleanup in this PR:
- The `Scalar` class now raises a `ValueError` if a symbolic scalar is converted to a number (this previously crashed anyway, but now there's a message)
- A couple type annotations for `BaseGraph` from #461 were updated to be more useful
- Type annotation syntax was modernised as much as possible without relying on typing_extensions
- Imports were standardised with isort and types were imported from `collections` instead of `typing` where appropriate
- Minor formatting changes