### PR TITLE
Fix to_tikz dropping Hadamards on boundary-incident edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ## [Unreleased]
 
+### Fixed
+- `to_tikz` no longer drops Hadamards on edges that touch a boundary. Such an edge was exported as a plain wire plus a `hadamard` node that no `\draw` referenced, so the Hadamard was lost on reimport and the diagram gained a disconnected H-box. These edges now use the same `hadamard edge` style as every other Hadamard edge (by @gauthamkanagaraj).
+
 ## [0.10.5] - 2026-08-01
 
 ### Fixed

--- a/pyzx/tikz.py
+++ b/pyzx/tikz.py
@@ -64,7 +64,6 @@ def _to_tikz(g: BaseGraph[VT,ET], draw_scalar:bool = False,
         s = "        \\node [style=none] ({:d}) at ({:.2f}, {:.2f}) {{{:s}}};".format(idoffset,x,y,scalar)
         idoffset += 1
         verts.append(s)
-    maxindex = idoffset
 
     for v in g.vertices():
         ty = g.type(v)
@@ -76,7 +75,6 @@ def _to_tikz(g: BaseGraph[VT,ET], draw_scalar:bool = False,
             y = - g.qubit(v) - yoffset
             s = f"        \\node [style={style}] ({v+idoffset}) at ({{x:.2f}}, {{y:.2f}}) {{{{{text}}}}};".format(x=x, y=y)
             verts.append(s)
-            maxindex = max([v+idoffset,maxindex])
             continue
         if ty == VertexType.Z_BOX:
             p = get_z_box_label(g,v)
@@ -122,22 +120,14 @@ def _to_tikz(g: BaseGraph[VT,ET], draw_scalar:bool = False,
         y = - g.qubit(v) - yoffset
         s = "        \\node [style={}] ({:d}) at ({:.2f}, {:.2f}) {{{:s}}};".format(style,v+idoffset,x,y,phase)
         verts.append(s)
-        maxindex = max([v+idoffset,maxindex])
     edges = []
     for e in g.edges():
         v,w = g.edge_st(e)
         et = g.edge_type(e)
         s = "        \\draw "
         if et == EdgeType.HADAMARD:
-            if g.type(v) != VertexType.BOUNDARY and g.type(w) != VertexType.BOUNDARY:
-                style = settings.tikz_classes['H-edge']
-                if style: s += "[style={:s}] ".format(style)
-            else:
-                x = (g.row(v) + g.row(w))/2.0 +xoffset
-                y = -(g.qubit(v)+g.qubit(w))/2.0 -yoffset
-                t = "        \\node [style={:s}] ({:d}) at ({:.2f}, {:.2f}) {{}};".format(settings.tikz_classes['H'],maxindex+1, x,y)
-                verts.append(t)
-                maxindex += 1
+            style = settings.tikz_classes['H-edge']
+            if style: s += "[style={:s}] ".format(style)
         elif et == EdgeType.W_IO:
             style = settings.tikz_classes['W-io-edge']
             if style: s += "[style={:s}] ".format(style)

--- a/tests/test_tikz.py
+++ b/tests/test_tikz.py
@@ -26,6 +26,7 @@ from pyzx.utils import EdgeType, VertexType
 from pyzx.tikz import tikz_to_graph, to_tikz
 from pyzx.graph.graph import Graph
 from pyzx.graph.jsonparser import string_to_phase
+from pyzx.tensor import compare_tensors
 
 
 class TestTikzErrorHandling(unittest.TestCase):
@@ -558,6 +559,77 @@ class TestTikzIdentityNodeRemoval(unittest.TestCase):
         vertices = list(g.vertices())
         e = g.edge(vertices[0], vertices[1])
         self.assertEqual(g.edge_type(e), EdgeType.W_IO)
+
+
+class TestTikzBoundaryHadamardEdges(unittest.TestCase):
+    """Hadamard edges touching a boundary survive a to_tikz round trip (issue #496)."""
+
+    @staticmethod
+    def _wire(edge_types):
+        """A single qubit wire of Z spiders whose edges have the given types."""
+        g = Graph()
+        vs = [g.add_vertex(VertexType.BOUNDARY, 0, 0)]
+        for i in range(len(edge_types) - 1):
+            vs.append(g.add_vertex(VertexType.Z, 0, i + 1))
+        vs.append(g.add_vertex(VertexType.BOUNDARY, 0, len(edge_types)))
+        for (v, w), et in zip(zip(vs, vs[1:]), edge_types):
+            g.add_edge((v, w), et)
+        g.set_inputs((vs[0],))
+        g.set_outputs((vs[-1],))
+        return g
+
+    @staticmethod
+    def _hadamard_edges(g):
+        return sum(1 for e in g.edges() if g.edge_type(e) == EdgeType.HADAMARD)
+
+    def _round_trip(self, g):
+        g2 = tikz_to_graph(to_tikz(g), warn_overlap=False)
+        g2.auto_detect_io()
+        return g2
+
+    def test_boundary_hadamard_edge_uses_the_hadamard_edge_style(self):
+        """A boundary Hadamard is a styled edge, not a node that no \\draw references."""
+        g = self._wire([EdgeType.HADAMARD, EdgeType.SIMPLE])
+        tikz = to_tikz(g)
+        self.assertIn(r"\draw [style=hadamard edge]", tikz)
+        self.assertNotIn(r"\node [style=hadamard]", tikz)
+
+    def test_hadamard_edge_at_input_boundary_round_trips(self):
+        """An H-edge on the input boundary comes back as an H-edge."""
+        g = self._wire([EdgeType.HADAMARD, EdgeType.SIMPLE])
+        g2 = self._round_trip(g)
+        self.assertEqual(self._hadamard_edges(g2), self._hadamard_edges(g))
+        self.assertEqual([v for v in g2.vertices() if g2.type(v) == VertexType.H_BOX], [])
+        self.assertTrue(compare_tensors(g, g2))
+
+    def test_hadamard_edge_at_output_boundary_round_trips(self):
+        """The boundary test is symmetric, so the output side must behave the same."""
+        g = self._wire([EdgeType.SIMPLE, EdgeType.HADAMARD])
+        g2 = self._round_trip(g)
+        self.assertEqual(self._hadamard_edges(g2), self._hadamard_edges(g))
+        self.assertEqual([v for v in g2.vertices() if g2.type(v) == VertexType.H_BOX], [])
+        self.assertTrue(compare_tensors(g, g2))
+
+    def test_hadamard_edges_at_both_boundaries_round_trip(self):
+        """Both boundaries at once, with an interior H-edge that was never affected."""
+        g = self._wire([EdgeType.HADAMARD, EdgeType.HADAMARD, EdgeType.HADAMARD])
+        g2 = self._round_trip(g)
+        self.assertEqual(self._hadamard_edges(g2), 3)
+        self.assertEqual([v for v in g2.vertices() if g2.type(v) == VertexType.H_BOX], [])
+        self.assertTrue(compare_tensors(g, g2))
+
+    def test_boundary_hadamard_preserves_the_scalar(self):
+        """An H-edge must not come back as an H-box, which differs from it by a factor sqrt(2)."""
+        g = self._wire([EdgeType.HADAMARD, EdgeType.SIMPLE])
+        g2 = self._round_trip(g)
+        self.assertTrue(compare_tensors(g, g2, preserve_scalar=True))
+
+    def test_interior_hadamard_edge_still_round_trips(self):
+        """The non-boundary path is unchanged."""
+        g = self._wire([EdgeType.SIMPLE, EdgeType.HADAMARD, EdgeType.SIMPLE])
+        g2 = self._round_trip(g)
+        self.assertEqual(self._hadamard_edges(g2), 1)
+        self.assertTrue(compare_tensors(g, g2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

When a Hadamard edge has a boundary vertex at either end, `to_tikz` wrote the wire as a plain edge and emitted a separate `hadamard` node that no `\draw` referenced. Since `tikz_to_graph` derives edge type from the `\draw` style, the wire came back as a `SIMPLE` edge and the node as a disconnected H-box, so the Hadamard was lost.

Boundary incident Hadamard edges now use the same `hadamard edge` style as every other Hadamard edge, and no separate node is emitted.

## Related issue

Fixes #496

## Checklist

- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation. (N/A - bugfix, no new feature)
- [x] All the functions I added have a docstring parsable by sphinx (N/A - no new functions added).
- [x] I have added an entry to CHANGELOG.md describing my change.