### PR TITLE
fix `match_phase_gadgets` bookkeeping for boolean axels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Fixed
 - `to_tikz` no longer drops Hadamards on edges that touch a boundary. Such an edge was exported as a plain wire plus a `hadamard` node that no `\draw` referenced, so the Hadamard was lost on reimport and the diagram gained a disconnected H-box. These edges now use the same `hadamard edge` style as every other Hadamard edge (by @gauthamkanagaraj).
+- `match_phase_gadgets` no longer treats a symbolic boolean axel as constant pi in its scalar and `phase_negate` bookkeeping. Symbolic-axel parity groups are skipped by default; opt in via `apply_to_boolean_axels=True` on `merge_phase_gadgets_for_simp`/`_for_apply`. (by @dlyongemallo)
 
 ## [0.10.5] - 2026-08-01
 

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -17,17 +17,22 @@
 
 """
 This module contains the implementation of the phase gadgets merging rule.
-This rule acts on an entire graph and the matcher modifies the graph, so this rule should only be run
-using the using simplify.gadget_simp(g) or simplify.gadget_simp.apply(g).
+This rule acts on an entire graph and the matcher modifies the graph, so this rule should normally
+be run using simplify.gadget_simp(g) or simplify.gadget_simp.apply(g).
+
+To opt in to absorbing a symbolic Boolean Poly axel into a non-Pauli leaf (which converts the
+Boolean parameter into a non-Boolean phase), call :func:`merge_phase_gadgets_for_simp` or
+:func:`merge_phase_gadgets_for_apply` directly with ``apply_to_boolean_axels=True``. The
+``simplify.gadget_simp`` wrapper cannot forward this keyword.
 """
 
-from typing import Tuple, List, Dict, FrozenSet, Union, cast
+from typing import Tuple, List, Dict, FrozenSet
 from typing import Optional
-
-from pyzx.utils import  FractionLike, phase_is_pauli
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.symbolic import Poly, new_const
 from fractions import Fraction
+
+from pyzx.utils import FractionLike, phase_is_pauli, push_pauli_axel
+from pyzx.graph.base import BaseGraph, VT, ET
+from pyzx.symbolic import Poly
 
 
 __all__ = ['merge_phase_gadgets_for_simp',
@@ -35,23 +40,26 @@ __all__ = ['merge_phase_gadgets_for_simp',
 
 MatchGadgetType = Tuple[VT,VT,FractionLike,List[VT],List[VT]]
 
-def merge_phase_gadgets_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def merge_phase_gadgets_for_simp(g: BaseGraph[VT,ET], apply_to_boolean_axels: bool = False) -> bool:
     """Runs :func:`match_phase_gadgets` and if any matches are found runs :func:`merge_phase_gadgets`"""
-    matches = match_phase_gadgets(g)
+    matches = match_phase_gadgets(g, apply_to_boolean_axels=apply_to_boolean_axels)
     if len(matches) == 0: return False
     return merge_phase_gadgets(g, matches)
 
-def merge_phase_gadgets_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def merge_phase_gadgets_for_apply(g: BaseGraph[VT,ET], vertices: List[VT], apply_to_boolean_axels: bool = False) -> bool:
     """Runs :func:`match_phase_gadgets` on the input vertices and if any matches are found runs :func:`merge_phase_gadgets`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
-    matches = match_phase_gadgets(g, checked_vertices)
+    matches = match_phase_gadgets(g, checked_vertices, apply_to_boolean_axels=apply_to_boolean_axels)
     if len(matches) == 0: return False
     return merge_phase_gadgets(g, matches)
 
-def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -> List[MatchGadgetType[VT]]:
+def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None, apply_to_boolean_axels: bool = False) -> List[MatchGadgetType[VT]]:
     """Determines which phase gadgets act on the same vertices, so that they can be fused together.
 
     :param g: An instance of a ZX-graph.
+    :param apply_to_boolean_axels: If False (default), parity groups containing a symbolic Boolean Poly
+        axel are skipped, since absorbing a Boolean axel into a non-Pauli leaf converts a Boolean
+        parameter into a non-Boolean phase. Set to True to opt in to the symbolic rewrite.
     :rtype: List of 5-tuples ``(axel,leaf, total combined phase, other axels with same targets, other leafs)``.
     .. warning:: Matcher function modifies the graph. Do not run multiple times without calling the applier between calls.
     """
@@ -83,45 +91,41 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
 
     m: List[MatchGadgetType[VT]] = []
     for par, gad in parities.items():
+        # Skip parity groups whose axels include a symbolic Boolean Poly unless the
+        # caller opted in: absorbing that axel here would convert its Boolean parameter
+        # into a non-Boolean phase.
+        if not apply_to_boolean_axels and any(
+                isinstance(p := phases[n], Poly) and len(p.free_vars()) > 0 for n in gad):
+            continue
         if len(gad) == 1:
             n = gad[0]
             v = gadgets[n]
-            axel_phase = phases[n]
-            is_symbolic = isinstance(axel_phase, Poly) and len(axel_phase.free_vars()) > 0
-            if axel_phase != 0 or is_symbolic:
-                g.scalar.add_phase(phases[v])
-                g.phase_negate(v)
-                if is_symbolic:
-                    if isinstance(phases[v], Poly):
-                        gadget_phase: FractionLike = phases[v]
-                    else:
-                        gadget_phase = new_const(cast(Union[int, Fraction], phases[v]))
-                  
-                    new_phase = gadget_phase + (-2 * gadget_phase) * phases[n]
-                    m.append((v, n, new_phase, [], []))
-                else:
-                    m.append((v, n, -phases[v], [], []))
+            ax = phases[n]
+            leaf = phases[v]
+            if ax != 0: # axel has a non-zero Pauli phase: absorb it into leaf and scalar.
+                g.scalar.add_phase(ax * leaf)
+                # phase_negate flips an unconditional sign that teleport_reduce reads back
+                # later. For symbolic Boolean axels the sign flip is conditional on the
+                # boolean's value and is already encoded in the new leaf phase
+                # (1 - 2*ax)*leaf, so calling phase_negate would double-account for it.
+                if not (isinstance(ax, Poly) and len(ax.free_vars()) > 0):
+                    g.phase_negate(v)
+                m.append((v, n, push_pauli_axel(ax, leaf), [], []))
         else:
             totphase: FractionLike = Fraction(0)
             for n in gad:
-                gadget_phase = phases[gadgets[n]]
-                if isinstance(phases[n], Poly):
-                    gp: FractionLike = gadget_phase if isinstance(gadget_phase, Poly) else new_const(gadget_phase)
-                    totphase += gp + (-gp - gp) * phases[n]
-                else:
-                    if phases[n] == 0:
-                        totphase += gadget_phase
-                    else:
-                        totphase += -gadget_phase
+                ax = phases[n]
+                leaf = phases[gadgets[n]]
+                if ax != 0:
+                    g.scalar.add_phase(ax * leaf)
+                    if not (isinstance(ax, Poly) and len(ax.free_vars()) > 0):
+                        g.phase_negate(gadgets[n])
+                totphase = totphase + push_pauli_axel(ax, leaf)
             totphase = totphase % 2
-            for n in gad:
-                if phases[n] != 0:
-                    g.scalar.add_phase(phases[gadgets[n]])
-                    g.phase_negate(gadgets[n])
             g.scalar.add_power(-((len(par)-1)*(len(gad)-1)))
             n = gad.pop()
             v = gadgets[n]
-            m.append((v,n,totphase, gad, [gadgets[n] for n in gad]))
+            m.append((v, n, totphase, gad, [gadgets[n] for n in gad]))
     return m
 
 def merge_phase_gadgets(g: BaseGraph[VT,ET], matches: List[MatchGadgetType[VT]]) -> bool:

--- a/tests/test_boolean_pauli_rewrites.py
+++ b/tests/test_boolean_pauli_rewrites.py
@@ -22,6 +22,7 @@ from pyzx.graph import Graph
 from pyzx.utils import EdgeType, VertexType
 from pyzx.symbolic import Poly, new_var
 from pyzx.simplify import gadget_simp, teleport_reduce
+from pyzx.rewrite_rules.merge_phase_gadget_rule import merge_phase_gadgets_for_simp
 from pyzx.rewrite_rules.push_pauli_rule import unsafe_pauli_push
 from pyzx.rewrite_rules.pivot_rule import unsafe_pivot
 from pyzx.tensor import compare_tensors
@@ -37,6 +38,66 @@ def tensors_match(g1, g2, **subs):
 
 
 class TestBooleanPauliRewrites(unittest.TestCase):
+
+    def test_gadget_simp(self):
+        """`gadget_simp` skips a boolean-axel gadget by default; the
+        opt-in ``apply_to_boolean_axels=True`` path runs the rewrite and
+        preserves the tensor under each substitution of the boolean."""
+        def build():
+            g = Graph()
+            c = new_var('c', is_bool=True, registry=g.var_registry)
+            b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+            b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+            t = g.add_vertex(VertexType.Z, 0, 2)
+            n = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+            v = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+            g.add_edge((b0, t)); g.add_edge((t, b1))
+            g.add_edge((t, n), EdgeType.HADAMARD); g.add_edge((n, v), EdgeType.HADAMARD)
+            g.set_inputs((b0,)); g.set_outputs((b1,))
+            return g
+
+        # Default path: gadget_simp leaves the boolean-axel gadget alone.
+        g_default = build()
+        self.assertFalse(gadget_simp(g_default))
+
+        # Opt-in path: apply via the underlying function (gadget_simp cannot
+        # forward the flag) and check tensor equivalence under each boolean value.
+        g_optin = build()
+        orig = g_optin.copy()
+        self.assertTrue(merge_phase_gadgets_for_simp(g_optin, apply_to_boolean_axels=True))
+        for c_val in (0, 1):
+            self.assertTrue(tensors_match(g_optin, orig, c=c_val),
+                            f"gadget_simp drifted at c={c_val}")
+
+    def test_teleport_reduce(self):
+        """`teleport_reduce` must commute with substitution for a boolean axel.
+
+        Two phase gadgets sharing parity {target}: boolean axel `c` and
+        constant pi axel, both with T leaves.
+        """
+        def build(c_val=None):
+            g = Graph()
+            c = (new_var('c', is_bool=True, registry=g.var_registry)
+                 if c_val is None else Fraction(c_val))
+            b0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+            b1 = g.add_vertex(VertexType.BOUNDARY, 0, 4)
+            t = g.add_vertex(VertexType.Z, 0, 2)
+            n1 = g.add_vertex(VertexType.Z, 1, 2, phase=c)
+            v1 = g.add_vertex(VertexType.Z, 2, 2, phase=Fraction(1, 4))
+            n2 = g.add_vertex(VertexType.Z, -1, 2, phase=Fraction(1))
+            v2 = g.add_vertex(VertexType.Z, -2, 2, phase=Fraction(1, 4))
+            g.add_edge((b0, t)); g.add_edge((t, b1))
+            g.add_edge((t, n1), EdgeType.HADAMARD); g.add_edge((n1, v1), EdgeType.HADAMARD)
+            g.add_edge((t, n2), EdgeType.HADAMARD); g.add_edge((n2, v2), EdgeType.HADAMARD)
+            g.set_inputs((b0,)); g.set_outputs((b1,))
+            return g
+
+        g_tel = teleport_reduce(build())
+        for c_val in (0, 1):
+            ref = teleport_reduce(build(c_val))
+            got = g_tel.substitute_variables({'c': Fraction(c_val)})
+            self.assertTrue(compare_tensors(ref, got),
+                            f"teleport_reduce drifted at c={c_val}")
 
     def test_unsafe_pauli_push(self):
         """`unsafe_pauli_push` skips a boolean Pauli by default and

--- a/tests/test_symbolic_parsing.py
+++ b/tests/test_symbolic_parsing.py
@@ -439,8 +439,19 @@ class TestPolyConjugate(unittest.TestCase):
 class TestSymbolicBooleanRewrite(unittest.TestCase):
 
     def test_t_injection_reduces_correctly(self):
-        """T injection should reduce to phase pi/4 regardless of measurement result."""
+        """`full_reduce` on a T-injection with a boolean-axel measurement outcome
+        must commute with substituting c[0].
 
+        Under the fix for issue #436, `full_reduce` no longer silently collapses
+        a boolean-axel gadget into a Pauli-negated phase (which produced the
+        c[0]=1 answer regardless of the actual boolean value); it preserves the
+        boolean structure. Correctness is expressed by tensor equivalence:
+        substituting c[0] into the reduced diagram yields the same linear map
+        as substituting c[0] into the unsimplified diagram, for both c[0]=0
+        and c[0]=1. `_r0` is the fresh boolean phase left by the leading
+        `reset` on the ancilla; we substitute it to 0 on both sides so the
+        tensors are concrete.
+        """
         circ = zx.qasm("""
 OPENQASM 2.0;
 include "qelib1.inc";
@@ -453,19 +464,15 @@ cx q[0],q[1];
 measure q[1] -> c[0];
 if (c==1) s q[0];
 """)
-        g = circ.to_graph()
-        zx.full_reduce(g)
-        # The leading `reset` on a fresh input leaves an orphan discard
-        # component with a fresh boolean phase that `full_reduce` does not
-        # remove. Drop it so only the injected phase remains.
-        zx.drop_orphan_reset_discards(g)
-
-        phases = g.phases()
-        non_zero = {v: p for v, p in phases.items() if p != 0}
-        self.assertEqual(len(non_zero), 1, f"Expected 1 non-zero phase, got {non_zero}")
-
-        actual_phase = list(non_zero.values())[0]
-        self.assertEqual(actual_phase, Fraction(1, 4), f"Expected Fraction(1,4), got {actual_phase}")
+        g_ref = circ.to_graph()
+        g_simp = circ.to_graph()
+        zx.full_reduce(g_simp)
+        for c_val in (0, 1):
+            subs = {'c[0]': Fraction(c_val), '_r0': Fraction(0)}
+            ref = g_ref.substitute_variables(subs)
+            got = g_simp.substitute_variables(subs)
+            self.assertTrue(zx.compare_tensors(ref, got, preserve_scalar=True),
+                            f"full_reduce diverged from reference for c[0]={c_val}")
 
 
 


### PR DESCRIPTION
## Description

The symbolic-axel branch fired `g.scalar.add_phase(leaf)` and `g.phase_negate(v)` unconditionally, treating the axel as constant `pi`. Fixed to `add_phase(ax * leaf)` and skip `phase_negate`.

(The conditional sign flip is already in the new leaf phase `(1 - 2*ax)*leaf`, so `teleport_reduce` would otherwise double-account when reading `phase_mult` back).

Uses the `apply_to_boolean_axels` opt-in added in #486.  Absorbing a boolean axel into a non-Pauli leaf converts a boolean parameter into a non-boolean phase; this boolean flag is added to `merge_phase_gadgets_for_simp`/`_for_apply`, and defaults to skip.

## Related issue

Completes the fix started in #451. Fixes #436.

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.