### PR TITLE
Fix automatic tensor contraction for non-ZX spiders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 ## [Unreleased]
 
 ### Fixed
+- Automatic tensor contraction now falls back to the naive strategy for diagrams containing vertex types other than boundaries, Z-spiders, or X-spiders, fixing default contraction for W-spiders and Z-boxes (by @henriquejsza).
 - `to_tikz` no longer drops Hadamards on edges that touch a boundary. Such an edge was exported as a plain wire plus a `hadamard` node that no `\draw` referenced, so the Hadamard was lost on reimport and the diagram gained a disconnected H-box. These edges now use the same `hadamard edge` style as every other Hadamard edge (by @gauthamkanagaraj).
 - `match_phase_gadgets` no longer treats a symbolic boolean axel as constant pi in its scalar and `phase_negate` bookkeeping. Symbolic-axel parity groups are skipped by default; opt in via `apply_to_boolean_axels=True` on `merge_phase_gadgets_for_simp`/`_for_apply`. (by @dlyongemallo)
 

--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -47,6 +47,12 @@ if TYPE_CHECKING:
     from .circuit import Circuit
 TensorConvertible = Union[np.ndarray, 'Circuit', 'BaseGraph']
 
+_RANK_WIDTH_VERTEX_TYPES = frozenset({
+    VertexType.BOUNDARY,
+    VertexType.Z,
+    VertexType.X,
+})
+
 def Z_box_to_tensor(arity: int, parameter: complex) -> np.ndarray:
     m = np.zeros([2]*arity, dtype = complex)
     if arity == 0:
@@ -128,7 +134,7 @@ def tensorfy(g: 'BaseGraph[VT,ET]',
         raise ValueError("Hybrid graphs are not supported.")
     if strategy == 'auto':
         from .graph.multigraph import Multigraph
-        if any(g.type(v) == VertexType.H_BOX for v in g.vertices()):
+        if any(g.type(v) not in _RANK_WIDTH_VERTEX_TYPES for v in g.vertices()):
             strategy = 'naive'
         elif isinstance(g, Multigraph): # TODO: fix full_reduce for Multigraph
             strategy = 'naive'

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -28,7 +28,7 @@ import math
 
 from pyzx.graph import Graph
 from pyzx.graph.multigraph import Multigraph
-from pyzx.generate import cliffords
+from pyzx.generate import cliffords, spider
 from pyzx.circuit import Circuit
 from pyzx.utils import VertexType, set_h_box_label
 
@@ -44,6 +44,19 @@ SEED = 1337
 
 @unittest.skipUnless(np, "numpy needs to be installed for this to run")
 class TestTensor(unittest.TestCase):
+
+    def test_tensorfy_auto_falls_back_for_non_zx_spiders(self):
+        """The auto strategy should use naive contraction for non-ZX spiders."""
+        for vertex_type in (
+            VertexType.H_BOX,
+            VertexType.W_OUTPUT,
+            VertexType.Z_BOX,
+        ):
+            with self.subTest(vertex_type=vertex_type):
+                graph = spider(vertex_type, 1, 2)
+                expected = tensorfy(graph, strategy='naive')
+                actual = tensorfy(graph)
+                self.assertTrue(np.allclose(actual, expected))
 
     def test_scalar_difference(self):
         array = np.array([[0,1],[1,0]])


### PR DESCRIPTION
## Description

The automatic tensor contraction strategy now sends only boundary/Z/X diagrams to the rank-width implementation and falls back to naive contraction for every other vertex type. This fixes the default `tensorfy` failure for W-spiders and Z-boxes while keeping the existing H-box and Multigraph fallbacks.

The regression test compares automatic and naive contraction for H-box, W-spider, and Z-box diagrams.

## Related issue

Fixes #500.

## Validation

- `mypy pyzx/ tests/`
- `python -m unittest discover -s tests -t . --verbose` (520 tests, 19 skipped)
- `sphinx-build -b html doc /tmp/pyzx-500-docs-html`
- `git diff --check`

## Checklist

- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: not applicable; this is a bug fix.
- [x] All the functions I added have a docstring parsable by sphinx (no functions added).
- [x] I have added an entry to CHANGELOG.md describing my change.
