### PR TITLE
Track scalar changes in GraphDiff serialization and application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 ## [Unreleased]
 
 ### Fixed
+- `GraphDiff` now tracks, applies, and serializes changes to a graph's global scalar. (by @RazinShaikh)
 - `to_tikz` no longer drops Hadamards on edges that touch a boundary. Such an edge was exported as a plain wire plus a `hadamard` node that no `\draw` referenced, so the Hadamard was lost on reimport and the diagram gained a disconnected H-box. These edges now use the same `hadamard edge` style as every other Hadamard edge (by @gauthamkanagaraj).
 - `match_phase_gadgets` no longer treats a symbolic boolean axel as constant pi in its scalar and `phase_negate` bookkeeping. Symbolic-axel parity groups are skipped by default; opt in via `apply_to_boolean_axels=True` on `merge_phase_gadgets_for_simp`/`_for_apply`. (by @dlyongemallo)
 

--- a/pyzx/graph/diff.py
+++ b/pyzx/graph/diff.py
@@ -25,6 +25,7 @@ from ..utils import EdgeType, FloatInt, FractionLike, VertexType, phase_to_s
 from .base import ET, VT, BaseGraph
 from .graph_s import GraphS
 from .jsonparser import string_to_phase
+from .scalar import Scalar
 
 
 class GraphDiff(Generic[VT, ET]):
@@ -40,11 +41,13 @@ class GraphDiff(Generic[VT, ET]):
     changed_edata: dict[ET, Any]
     variable_types: dict[str, bool]
     var_registry: VarRegistry
+    changed_scalar: Scalar | None
 
     def __init__(self, g1: BaseGraph[VT, ET], g2: BaseGraph[VT, ET]) -> None:
         self.calculate_diff(g1,g2)
 
     def calculate_diff(self, g1: BaseGraph[VT, ET], g2: BaseGraph[VT, ET]) -> None:
+        self.changed_scalar = g2.scalar.copy() if g1.scalar != g2.scalar else None
         self.changed_vertex_types = {}
         self.changed_edge_types = {}
         self.changed_phases = {}
@@ -155,6 +158,8 @@ class GraphDiff(Generic[VT, ET]):
 
         for name in self.var_registry.vars():
             g.var_registry.set_type(name, self.var_registry.get_type(name))
+        if self.changed_scalar is not None:
+            g.scalar = self.changed_scalar.copy()
         g.rebind_variables_to_registry()
         return g
 
@@ -166,7 +171,7 @@ class GraphDiff(Generic[VT, ET]):
         for key, value in self.changed_edata.items():
             changed_edata_str_dict[f"{key[0]},{key[1]}"] = value # type: ignore
         changed_phases_str = {k: phase_to_s(v, limit_denominator=False) for k, v in self.changed_phases.items()}
-        return {
+        diff = {
             "removed_verts": self.removed_verts,
             "new_verts": self.new_verts,
             "removed_edges": self.removed_edges,
@@ -179,6 +184,9 @@ class GraphDiff(Generic[VT, ET]):
             "changed_edata": changed_edata_str_dict,
             "variable_types": self.var_registry.types,
         }
+        if self.changed_scalar is not None:
+            diff["changed_scalar"] = self.changed_scalar.to_dict()
+        return diff
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
@@ -203,6 +211,8 @@ class GraphDiff(Generic[VT, ET]):
             gd.changed_edata = map_dict_keys(d["changed_edata"], lambda x: tuple(map(int, x.split(","))))
         else:
             gd.changed_edata = {}
+        changed_scalar = d.get("changed_scalar")
+        gd.changed_scalar = Scalar.from_json(changed_scalar) if changed_scalar is not None else None
         return gd
 
 def map_dict_keys(d: dict[str, Any], f: Callable[[str], Any]) -> dict[Any, Any]:

--- a/tests/test_jsonparser.py
+++ b/tests/test_jsonparser.py
@@ -442,6 +442,37 @@ class TestGraphIO(unittest.TestCase):
         self.assertEqual(get_h_box_label(g2, v2_new), 1j)
         self.assertEqual(get_h_box_label(g2, v3_new), 2.5+1.3j)
 
+class TestGraphDiff(unittest.TestCase):
+
+    def test_scalar_change_roundtrip(self):
+        g1 = Graph()
+        g2 = g1.clone()
+        g2.scalar.power2 = 3
+        g2.scalar.phase = Fraction(1, 4)
+        g2.scalar.phasenodes = [Fraction(1, 2)]
+        g2.scalar.sum_of_phases = {Fraction(3, 4): 2}
+        g2.scalar.floatfactor = 2.5 + 1.5j
+
+        diff = GraphDiff(g1, g2)
+        roundtripped_diff = GraphDiff.from_json(diff.to_json())
+
+        self.assertEqual(diff.apply_diff(g1).scalar, g2.scalar)
+        self.assertEqual(roundtripped_diff.changed_scalar, g2.scalar)
+        applied = roundtripped_diff.apply_diff(g1)
+        self.assertEqual(applied.scalar, g2.scalar)
+        self.assertIsNot(applied.scalar, roundtripped_diff.changed_scalar)
+
+    def test_unchanged_scalar_is_omitted(self):
+        g = Graph()
+        diff = GraphDiff(g, g.clone())
+
+        self.assertIsNone(diff.changed_scalar)
+        self.assertNotIn("changed_scalar", diff.to_dict())
+
+        legacy_diff = GraphDiff.from_json(diff.to_json())
+        self.assertIsNone(legacy_diff.changed_scalar)
+        self.assertEqual(legacy_diff.apply_diff(g).scalar, g.scalar)
+
 class TestStringToPhase(unittest.TestCase):
 
     def test_numeric_expression_parses_to_fraction(self):


### PR DESCRIPTION
## Description
`GraphDiff` now records and applies changes to a graph's global scalar, including when the diff is serialized to JSON.

Two regression tests verify changed scalars are preserved and unchanged scalars continue to work correctly.

## Related issue
None.

## Checklist
- [x] I have added/updated tests.
- [x] I have added an entry to CHANGELOG.md describing my change.