### PR TITLE
Raise error when computing Pauli webs on graph which has H-boxes with non-zero phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Fixed
 - Moved `RootHeuristic.RootHeuristicProtocol` and `SplitHeuristic.SplitHeuristicProtocol` to module level to fix a `DeprecationWarning` in Python 3.11+. Though these classes exist only for type annotations, this is technically a breaking change. (by @96-LB)
-- The `pyzx.web` module now raises an error when computing Pauli webs of a graph which has H-boxes with non-zero phase, instead of returning an invalid web which ignores the phase. (by @96-LB)
+- The `pyzx.web` module now raises an error when computing Pauli webs of a graph which has H-boxes with non-default phase, instead of returning an invalid web which ignores the phase. (by @96-LB)
 
 ### Removed
 - Support for the PyQuil compiler was dropped. Breaking changes include the removal of `PyQuilCircuit`, `Architecture.to_quil_device`, `CompileMode.QUIL_COMPILER`, and any related functionality in the scripts module. (by @96-LB)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ## [Unreleased]
 
+### Fixed
+- The `pyzx.web` module now raises an error when computing Pauli webs of a graph which has H-boxes with non-zero phase, instead of returning an invalid web which ignores the phase. (by @96-LB)
+
 ### Removed
 - Support for the PyQuil compiler was dropped. Breaking changes include the removal of `PyQuilCircuit`, `Architecture.to_quil_device`, `CompileMode.QUIL_COMPILER`, and any related functionality in the scripts module. (by @96-LB)
 - Support for the `graph_tool` and `igraph` backends has been officially dropped. (by @96-LB)

--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -151,29 +151,30 @@ def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[Expanded
         if g.type(v) != VertexType.H_BOX:
             continue
         
-        try:
-            v1, v2 = g.neighbors(v)
-        except ValueError:
+        neighbors = g.neighbors(v)
+        if len(neighbors) != 2:
             raise ValueError(f"Hadamard vertex {v} does not have exactly two neighbors.")
         
         if g.phase(v) != 0:
             raise ValueError(f"Hadamard vertex {v} has non-zero phase.")
         
+        v1, v2 = neighbors
         v1_edge_type = g.edge_type((v1, v))
         v2_edge_type = g.edge_type((v2, v))
 
         g.remove_vertex(v)
         g.add_edge((v1, v2))
 
-        flip = g.type(v1) == g.type(v2) and g.type(v1) == VertexType.X
+        flip = (g.type(v1) == g.type(v2) == VertexType.X)
         w1, w2, w3 = _decompose_between(v1, v2, flip)
         g.set_edge_type((v1, w1), v1_edge_type)
         g.set_edge_type((w3, v2), v2_edge_type)
 
         expanded_hadamards.append(ExpandedHadamard(w1, w2, w3, origin=v, flipped_decomposition=flip))
 
-    for v1, v2 in list(filter(lambda e: g.edge_type(e) == EdgeType.HADAMARD, g.edges())):
-        flip = g.type(v1) == g.type(v2) and g.type(v1) == VertexType.Z
+    hadamard_edges = (e for e in g.edges() if g.edge_type(e) == EdgeType.HADAMARD)
+    for v1, v2 in hadamard_edges:
+        flip = (g.type(v1) == g.type(v2) == VertexType.Z)
         w1, w2, w3 = _decompose_between(v1, v2, flip)
         expanded_hadamards.append(ExpandedHadamard(w1, w2, w3, origin=None, flipped_decomposition=flip))
 

--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -156,6 +156,9 @@ def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[Expanded
         except ValueError:
             raise ValueError(f"Hadamard vertex {v} does not have exactly two neighbors.")
         
+        if g.phase(v) != 0:
+            raise ValueError(f"Hadamard vertex {v} has non-zero phase.")
+        
         v1_edge_type = g.edge_type((v1, v))
         v2_edge_type = g.edge_type((v2, v))
 

--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -150,14 +150,14 @@ def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[Expanded
     for v in list(g.vertices()):
         if g.type(v) != VertexType.H_BOX:
             continue
-        
+
         neighbors = g.neighbors(v)
         if len(neighbors) != 2:
             raise ValueError(f"Hadamard vertex {v} does not have exactly two neighbors.")
-        
-        if g.phase(v) != 0:
-            raise ValueError(f"Hadamard vertex {v} has non-zero phase.")
-        
+
+        if g.phase(v) != 1:
+            raise ValueError(f"H-box vertex {v} has incorrect phase. Hadamard gates should have phase pi.")
+
         v1, v2 = neighbors
         v1_edge_type = g.edge_type((v1, v))
         v2_edge_type = g.edge_type((v2, v))


### PR DESCRIPTION
Currently, the `pyzx.web` module ignores phases on H-boxes, computing Pauli webs as if the phase is 0. This is not generally correct, so this PR adds a check which raises an error if there exist any H-boxes with non-zero phase. While I was in the relevant function, I also made a couple minor improvements to readability and performance in the surrounding code.