### PR TITLE
Fix `DeprecationWarning` due to nested classes inside `pyzx.routing` enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ## [Unreleased]
 
+### Fixed
+- Moved `RootHeuristic.RootHeuristicProtocol` and `SplitHeuristic.SplitHeuristicProtocol` to module level to fix a `DeprecationWarning` in Python 3.11+. Though these classes exist only for type annotations, this is technically a breaking change. (by @96-LB)
+
 ### Removed
 - Support for the PyQuil compiler was dropped. Breaking changes include the removal of `PyQuilCircuit`, `Architecture.to_quil_device`, `CompileMode.QUIL_COMPILER`, and any related functionality in the scripts module. (by @96-LB)
 - Support for the `graph_tool` and `igraph` backends has been officially dropped. (by @96-LB)

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -59,6 +59,21 @@ class RoutingMethod(Enum):
         return f"{self.value}"
 
 
+class RootHeuristicProtocol(Protocol):
+    """Function signature of heuristics for choosing the root of a Steiner tree during phase polynomial routing."""
+
+    def __call__(
+        self,
+        architecture: Architecture,
+        matrix: Mat2,
+        cols_to_use: list[int],
+        qubits: list[int],
+        column: int,
+        phase_qubit: int,
+        **kwargs: Any
+    ) -> list[tuple[int, int]]:
+        ...
+
 class RootHeuristic(Enum):
     """
     Heuristics for choosing the root of a Steiner tree during phase polynomial routing.
@@ -81,20 +96,6 @@ class RootHeuristic(Enum):
         Converts RootHeuristic into a string
         """
         return f"{self.value}"
-    
-    
-    class RootHeuristicProtocol(Protocol):
-        def __call__(
-            self,
-            architecture: Architecture,
-            matrix: Mat2,
-            cols_to_use: list[int],
-            qubits: list[int],
-            column: int,
-            phase_qubit: int,
-            **kwargs: Any
-        ) -> list[tuple[int, int]]:
-            ...
 
     def to_function(self) -> RootHeuristicProtocol:
         """
@@ -111,6 +112,20 @@ class RootHeuristic(Enum):
             return rec_root_heuristic
         else:
             raise KeyError(f"The root heuristic '{self}' is not implemented")
+
+
+class SplitHeuristicProtocol(Protocol):
+    """Function signature of heuristics for choosing nodes to split a circuit during phase polynomial routing."""
+
+    def __call__(
+        self,
+        architecture: Architecture,
+        matrix: Mat2,
+        cols_to_use: list[int],
+        qubits: list[int],
+        **kwargs: Any
+    ) -> list[int]:
+        ...
 
 
 class SplitHeuristic(Enum):
@@ -132,17 +147,6 @@ class SplitHeuristic(Enum):
         Converts SplitHeuristic into a string
         """
         return f"{self.value}"
-    
-    class SplitHeuristicProtocol(Protocol):
-        def __call__(
-            self,
-            architecture: Architecture,
-            matrix: Mat2,
-            cols_to_use: list[int],
-            qubits: list[int],
-            **kwargs: Any
-        ) -> list[int]:
-            ...
 
     def to_function(
         self,


### PR DESCRIPTION
Fixes #507.

Moves `RootHeuristicProtocol` and `SplitHeuristicProtocol` to module level as the linked issue suggests. Since this is technically a breaking change for code which references the classes (though this is unlikely to happen except when being used as type annotations in external code), a small warning was added in the changelog.