### PR TITLE
Enforce type annotations in `pyzx.web`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,17 +77,15 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = [
     "pyzx.graph.*",
-    "pyzx.circuit.*"
+    "pyzx.circuit.*",
+    "pyzx.routing.*",
+    "pyzx.web.*"
 ]
 disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "pyzx.optimize"
 ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "pyzx.routing.*"
-disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 module = [
-    "pyzx.graph.*",
     "pyzx.circuit.*",
+    "pyzx.graph.*",
     "pyzx.routing.*",
     "pyzx.web.*"
 ]

--- a/pyzx/web/compute.py
+++ b/pyzx/web/compute.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple, List, cast
+from typing import cast
 
 from .red_green import to_red_green_form
 from .firing_assignments import (
@@ -28,8 +28,8 @@ from ..pauliweb import PauliWeb
 
 
 def _compute(
-    graph: BaseGraph[int, Tuple[int, int]], *, stabilisers: bool, detecting_regions: bool
-) -> Tuple[Optional[List[PauliWeb[int, Tuple[int, int]]]], Optional[List[PauliWeb[int, Tuple[int, int]]]]]:
+    graph: BaseGraph[int, tuple[int, int]], *, stabilisers: bool, detecting_regions: bool
+) -> tuple[list[PauliWeb[int, tuple[int, int]]] | None, list[PauliWeb[int, tuple[int, int]]] | None]:
     """
     Performs full stabiliser and detecting region computation, depending on the given flags. Enabling both flags in one
     call is preferred to enabling them in separate calls as they may share basic computations.
@@ -98,7 +98,7 @@ def _compute(
     return stabs, regions
 
 
-def compute_stabilisers(graph: BaseGraph[int, Tuple[int, int]]) -> List[PauliWeb[int, Tuple[int, int]]]:
+def compute_stabilisers(graph: BaseGraph[int, tuple[int, int]]) -> list[PauliWeb[int, tuple[int, int]]]:
     """
     :return: A set of stabilising webs for the given diagram that forms a basis for the diagrams stabilisers when
         restricted to its boundary. A full basis for all stabilising webs is only obtained by combining the return value
@@ -111,7 +111,7 @@ def compute_stabilisers(graph: BaseGraph[int, Tuple[int, int]]) -> List[PauliWeb
     return stabs
 
 
-def compute_detecting_regions(graph: BaseGraph[int, Tuple[int, int]]) -> List[PauliWeb[int, Tuple[int, int]]]:
+def compute_detecting_regions(graph: BaseGraph[int, tuple[int, int]]) -> list[PauliWeb[int, tuple[int, int]]]:
     """
     :return: A basis for the detecting regions of the given diagram.
     """
@@ -122,8 +122,8 @@ def compute_detecting_regions(graph: BaseGraph[int, Tuple[int, int]]) -> List[Pa
     return regions
 
 
-def compute_pauli_webs(graph: BaseGraph[int, Tuple[int, int]])\
-        -> Tuple[List[PauliWeb[int, Tuple[int, int]]], List[PauliWeb[int, Tuple[int, int]]]]:
+def compute_pauli_webs(graph: BaseGraph[int, tuple[int, int]])\
+        -> tuple[list[PauliWeb[int, tuple[int, int]]] | None, list[PauliWeb[int, tuple[int, int]]] | None]:
     """
     See .compute_stabilisers and .compute_detecting_regions of this package.
     """

--- a/pyzx/web/firing_assignments.py
+++ b/pyzx/web/firing_assignments.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, NamedTuple, Tuple, cast
+from typing import NamedTuple, cast
 
 from ..graph.base import BaseGraph
 from ..linalg import Z2, Mat2
@@ -31,12 +31,12 @@ class GraphOrdering(NamedTuple):
     The collections identify vertices from the graph and mappings between the ordering and the graph vertex ids
     are provided.
     """
-    graph_to_ordering: Dict[int, int]
-    ordering_to_graph: Dict[int, int]
+    graph_to_ordering: dict[int, int]
+    ordering_to_graph: dict[int, int]
 
-    z_boundaries: Dict[int, int]
-    internal_spiders: List[int]
-    pi_2_spiders: List[int]
+    z_boundaries: dict[int, int]
+    internal_spiders: list[int]
+    pi_2_spiders: list[int]
 
     def ord(self, s: int) -> int:
         return self.graph_to_ordering[s]
@@ -45,7 +45,7 @@ class GraphOrdering(NamedTuple):
         return self.ordering_to_graph[o]
 
 
-def determine_ordering(g: BaseGraph[int, Tuple[int, int]]) -> GraphOrdering:
+def determine_ordering(g: BaseGraph[int, tuple[int, int]]) -> GraphOrdering:
     """
     Creates an ordering of all vertices in the graph, such that the three groups of spiders (see GraphOrdering class
     for details) have contiguous ordering indices. The group order is:
@@ -56,8 +56,8 @@ def determine_ordering(g: BaseGraph[int, Tuple[int, int]]) -> GraphOrdering:
     internal_spiders = list(g.vertex_set().difference(boundaries).difference(z_boundaries.keys()))
     pi_2_spiders = list(filter(lambda _v: g.phase(_v).denominator == 2, internal_spiders))
 
-    graph_to_ordering: Dict[int, int] = dict()
-    ordering_to_graph: Dict[int, int] = dict()
+    graph_to_ordering: dict[int, int] = {}
+    ordering_to_graph: dict[int, int] = {}
     idx = 0
     for boundary in z_boundaries.keys():
         graph_to_ordering[boundary] = idx
@@ -75,7 +75,7 @@ def determine_ordering(g: BaseGraph[int, Tuple[int, int]]) -> GraphOrdering:
     return GraphOrdering(graph_to_ordering, ordering_to_graph, z_boundaries, internal_spiders, pi_2_spiders)
 
 
-def create_firing_verification(g: BaseGraph[int, Tuple[int, int]], ordering: GraphOrdering) -> Mat2:
+def create_firing_verification(g: BaseGraph[int, tuple[int, int]], ordering: GraphOrdering) -> Mat2:
     """
     Based on a graph with an accompanying vertex ordering, creates a 'firing verification matrix' that exactly has the
     space of all valid firing assignments (equivalent to Pauli webs) as its nullspace.
@@ -107,8 +107,8 @@ def create_firing_verification(g: BaseGraph[int, Tuple[int, int]], ordering: Gra
 
 
 def convert_firing_assignment_to_web_prototype(
-    g: BaseGraph[int, Tuple[int, int]], ordering: GraphOrdering, v: List[Z2]
-) -> PauliWeb:
+    g: BaseGraph[int, tuple[int, int]], ordering: GraphOrdering, v: list[Z2]
+) -> PauliWeb[int, tuple[int, int]]:
     """
     Based on a graph with an accompanying vertex ordering, takes a valid firing assignment and converts it to a Pauli
     web valid on the given graph. Note that the graph is assumed to be in red-green form, and functions from this file

--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -53,13 +53,13 @@ class AdditionalNodes:
     def empty() -> "AdditionalNodes":
         return AdditionalNodes([], [])
 
-    def add_extra_id_node(self, node: int):
+    def add_extra_id_node(self, node: int) -> None:
         self.extra_id_nodes.append(ExtraIdNode(node))
 
-    def add_expanded_hadamard(self, expanded_hadamard: ExpandedHadamard):
+    def add_expanded_hadamard(self, expanded_hadamard: ExpandedHadamard) -> None:
         self.expanded_hadamards.append(expanded_hadamard)
 
-    def _remove_extra_id_node(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, id_node: ExtraIdNode):
+    def _remove_extra_id_node(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, id_node: ExtraIdNode) -> None:
         v1, v2 = adj[id_node.node].keys()
         web.add_half_edge((v1, v2), web[v1, id_node.node])
         web.add_half_edge((v2, v1), web[v1, id_node.node])
@@ -71,7 +71,7 @@ class AdditionalNodes:
         del adj[id_node.node][v2]
         del adj[v2][id_node.node]
 
-    def _remove_expanded_hadamard(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, hadamard: ExpandedHadamard):
+    def _remove_expanded_hadamard(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, hadamard: ExpandedHadamard) -> None:
         w1, w2, w3 = hadamard.r1_node, hadamard.r2_node, hadamard.r3_node
         w1_left, w1_right = adj[w1].keys()
         l = w1_left if w1_right == w2 else w1_right

--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Dict, List, Tuple, Iterable, Optional, Any
+from typing import Any
 
 from ..pauliweb import PauliWeb
 from ..utils import VertexType, EdgeType
@@ -33,7 +34,7 @@ class ExpandedHadamard:
     r1_node: int
     r2_node: int
     r3_node: int
-    origin: Optional[int]
+    origin: int | None
     flipped_decomposition: bool
 
 
@@ -42,10 +43,10 @@ class AdditionalNodes:
     Represents collections of additional nodes introduced during conversion of a graph to red-green form, additionally
     storing the original identities of the removed nodes (if any).
     """
-    extra_id_nodes: List[ExtraIdNode]
-    expanded_hadamards: List[ExpandedHadamard]
+    extra_id_nodes: list[ExtraIdNode]
+    expanded_hadamards: list[ExpandedHadamard]
 
-    def __init__(self, extra_id_nodes: List[ExtraIdNode], expanded_hadamards: List[ExpandedHadamard]):
+    def __init__(self, extra_id_nodes: list[ExtraIdNode], expanded_hadamards: list[ExpandedHadamard]):
         self.extra_id_nodes = extra_id_nodes
         self.expanded_hadamards = expanded_hadamards
 
@@ -59,7 +60,7 @@ class AdditionalNodes:
     def add_expanded_hadamard(self, expanded_hadamard: ExpandedHadamard) -> None:
         self.expanded_hadamards.append(expanded_hadamard)
 
-    def _remove_extra_id_node(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, id_node: ExtraIdNode) -> None:
+    def _remove_extra_id_node(self, adj: dict[int, dict[int, Any]], web: PauliWeb[int, tuple[int, int]], id_node: ExtraIdNode) -> None:
         v1, v2 = adj[id_node.node].keys()
         web.add_half_edge((v1, v2), web[v1, id_node.node])
         web.add_half_edge((v2, v1), web[v1, id_node.node])
@@ -71,7 +72,7 @@ class AdditionalNodes:
         del adj[id_node.node][v2]
         del adj[v2][id_node.node]
 
-    def _remove_expanded_hadamard(self, adj: Dict[int, Dict[int, Any]], web: PauliWeb, hadamard: ExpandedHadamard) -> None:
+    def _remove_expanded_hadamard(self, adj: dict[int, dict[int, Any]], web: PauliWeb[int, tuple[int, int]], hadamard: ExpandedHadamard) -> None:
         w1, w2, w3 = hadamard.r1_node, hadamard.r2_node, hadamard.r3_node
         w1_left, w1_right = adj[w1].keys()
         l = w1_left if w1_right == w2 else w1_right
@@ -103,7 +104,7 @@ class AdditionalNodes:
         del adj[w3][r]
         del adj[r][w3]
 
-    def remove_from(self, g: BaseGraph[int, Tuple[int, int]], web: PauliWeb) -> None:
+    def remove_from(self, g: BaseGraph[int, tuple[int, int]], web: PauliWeb[int, tuple[int, int]]) -> None:
         """
         For a given graph in red-green form and a Pauli web that is valid on it, reverses the node introduction used to
         achieve the red-green form on the Pauli web. That is, this function fuses neighbouring edge colorings in the web
@@ -116,7 +117,7 @@ class AdditionalNodes:
             self._remove_expanded_hadamard(adj, web, hadamard)
 
 
-def _place_node_between(g: BaseGraph[int, Tuple[int, int]], _type: VertexType, n1: int, n2: int) -> int:
+def _place_node_between(g: BaseGraph[int, tuple[int, int]], _type: VertexType, n1: int, n2: int) -> int:
     node = g.add_vertex(_type)
     g.remove_edge((n1, n2))
     g.add_edges([(n1, node), (node, n2)])
@@ -128,12 +129,12 @@ _euler_decomposition_xzx = [VertexType.X, VertexType.Z, VertexType.X]
 _euler_decomposition_zxz = [VertexType.Z, VertexType.X, VertexType.Z]
 
 
-def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[ExpandedHadamard]:
+def _euler_expand_edges(g: BaseGraph[int, tuple[int, int]]) -> Iterable[ExpandedHadamard]:
     """
     A cut down version of pyzx.euler_expansion which does not add global scalars and does not prematurely 'merge' spiders
     """
 
-    def _decompose_between(_v1: int, _v2: int, _flip: bool) -> Tuple[int, int, int]:
+    def _decompose_between(_v1: int, _v2: int, _flip: bool) -> tuple[int, int, int]:
         # Change decomposition to avoid introducing more X-spiders due to adjacent Z-spider
         pattern = _euler_decomposition_xzx if _flip else _euler_decomposition_zxz
 
@@ -181,7 +182,7 @@ def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[Expanded
     return expanded_hadamards
 
 
-def _ensure_red_green(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[int]:
+def _ensure_red_green(g: BaseGraph[int, tuple[int, int]]) -> Iterable[int]:
     new_nodes = []
     # Introduce intermediate nodes
     for s, t in list(g.edges()):
@@ -213,7 +214,7 @@ def _ensure_red_green(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[int]:
     return new_nodes
 
 
-def to_red_green_form(g: BaseGraph[int, Tuple[int, int]]) -> AdditionalNodes:
+def to_red_green_form(g: BaseGraph[int, tuple[int, int]]) -> AdditionalNodes:
     """
     Converts a graph to red-green form in-place. Returns an object that identifies all nodes introduced / removed and
     that can reverse the conversion process on Pauli webs of the converted graph. See the AdditionalNodes class for


### PR DESCRIPTION
This module is recent enough to have most of its annotations already in place, so this PR only added a couple explicit annotations for functions which returned None and fully qualified a couple generic `PauliWeb` annotations. To stay in line with the rest of the codebase, the existing type annotations have also been updated to the 3.10 syntax.