### PR TITLE
Enforce type annotations in `pyzx.rewrite_rules`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ warn_unused_configs = true
 module = [
     "pyzx.circuit.*",
     "pyzx.graph.*",
+    "pyzx.rewrite_rules.*",
     "pyzx.routing.*",
     "pyzx.web.*"
 ]

--- a/pyzx/rewrite_rules/add_identity_rule.py
+++ b/pyzx/rewrite_rules/add_identity_rule.py
@@ -32,12 +32,12 @@ __all__ = ['check_edge',
            'add_Z_identity',
            'unsafe_add_Z_identity']
 
-from pyzx.utils import EdgeType, VertexType
-from pyzx.graph.base import BaseGraph, VT, ET, upair
+from ..utils import EdgeType, VertexType
+from ..graph.base import BaseGraph, VT, ET, upair
 
 
 
-def check_edge(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
+def check_edge(g: BaseGraph[VT, ET], v:VT, w:VT) -> bool:
     """Checks if two vertices are connected by an unambiguous SIMPLE or HADAMARD edge.
 
     Returns False if `v` and `w` are the same vertex (self-loops are not
@@ -58,14 +58,14 @@ def check_edge(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
         return False
     return True
 
-def add_Z_identity( g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
+def add_Z_identity( g: BaseGraph[VT, ET], v:VT, w:VT) -> bool:
     """First checks if the 2 given vertices are connected by an edge, and then adds a Z spider to that edge.
      """
     if check_edge(g,v,w): return unsafe_add_Z_identity(g,v,w)
     return False
 
 
-def unsafe_add_Z_identity(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
+def unsafe_add_Z_identity(g: BaseGraph[VT, ET], v:VT, w:VT) -> bool:
     """Adds a Z spider to the edge given by the input vertices.
 
     Requires a unique edge type between `v` and `w`; raises ``ValueError`` on

--- a/pyzx/rewrite_rules/bialgebra_rule.py
+++ b/pyzx/rewrite_rules/bialgebra_rule.py
@@ -40,15 +40,13 @@ __all__ = ['check_bialgebra_reduce',
            ]
 
 from collections import defaultdict
-from typing import Callable, Optional, List, Tuple, Dict
-from pyzx.utils import (EdgeType, FractionLike, VertexType, is_pauli,
-                        is_standard_hbox)
-from pyzx.graph.base import BaseGraph, VT, ET, upair
+from ..utils import EdgeType, FractionLike, VertexType, is_pauli, is_standard_hbox
+from ..graph.base import BaseGraph, VT, ET, upair
 
-RewriteOutputType = Tuple[Dict[Tuple[VT,VT],List[int]], List[VT], List[ET], bool]
+RewriteOutputType = tuple[dict[tuple[VT, VT], list[int]], list[VT], list[ET], bool]
 
 
-def check_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT) -> bool:
+def check_bialgebra(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     """Checks if the bialgebra rule can be applied to a given pair of vertices.
     Supports both Z-X bialgebra and X-H bialgebra (X spider with standard H-box)."""
     if not (v1 in g.vertices() and v2 in g.vertices()): return False
@@ -72,7 +70,7 @@ def check_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT) -> bool:
 
     return False
 
-def _is_valid_reduce_neighbor(g: BaseGraph[VT,ET], n: VT, expected_type: VertexType) -> bool:
+def _is_valid_reduce_neighbor(g: BaseGraph[VT, ET], n: VT, expected_type: VertexType) -> bool:
     """Checks if a neighbour is valid for bialgebra reduction.
     For H-boxes, requires a standard H-box. For spiders, requires phase 0."""
     if g.type(n) != expected_type:
@@ -81,7 +79,7 @@ def _is_valid_reduce_neighbor(g: BaseGraph[VT,ET], n: VT, expected_type: VertexT
         return is_standard_hbox(g, n)
     return g.phase(n) == 0
 
-def check_bialgebra_reduce(g: BaseGraph[VT,ET], v1: VT, v2: VT) -> bool:
+def check_bialgebra_reduce(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     """Checks if the bialgebra rule can be applied to a given pair of vertices.
     Supports both Z-X and X-H bialgebra.
     NOTE: only returns true if the spiders are not neighbouring any boundary vertices."""
@@ -100,7 +98,7 @@ def bialgebra(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     if not check_bialgebra(g, v1, v2): return False
     return unsafe_bialgebra(g, v1, v2)
 
-def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
+def unsafe_bialgebra(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     """Applies the bialgebra rule to a given pair of spiders (Z-X or X-H)."""
     rem_verts = []
     etab = {}
@@ -108,7 +106,7 @@ def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
     rem_verts.append(v1)
     rem_verts.append(v2)
     v = (v1,v2)
-    new_verts: Tuple[List[VT],List[VT]] = ([],[]) # new vertices for v1 and v2
+    new_verts: tuple[list[VT], list[VT]] = ([], []) # new vertices for v1 and v2
 
     # Determine the vertex type and phase for copies placed at each side's
     # neighbours. copy_type[i] is the type for new vertices at v[i]'s
@@ -116,7 +114,7 @@ def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
     # For Z-X bialgebra: neighbours of v[i] get copies of v[j].
     # For X-H bialgebra: neighbours of X get H-box copies (phase 1), but
     # neighbours of the H-box get Z spiders (phase 0), not X spiders.
-    copy_phase: Tuple[FractionLike, FractionLike]
+    copy_phase: tuple[FractionLike, FractionLike]
     if g.type(v1) == VertexType.H_BOX or g.type(v2) == VertexType.H_BOX:
         if g.type(v1) == VertexType.X:
             copy_type = (VertexType.H_BOX, VertexType.Z)
@@ -130,7 +128,7 @@ def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
 
     for i, j in [(0, 1), (1, 0)]:
         multi_edge_found = False
-        neighbour_edge_count: dict = {}
+        neighbour_edge_count: dict[VT, int] = {}
         for e in g.incident_edges(v[i]):
             source, target = g.edge_st(e)
             other_vertex = source if source != v[i] else target
@@ -191,13 +189,13 @@ def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
     g.add_edge_table(etab)
     return True
 
-def simp_bialgebra_op(g: BaseGraph[VT,ET]) -> bool:
+def simp_bialgebra_op(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_bialgebra_op` and if any matches are found runs :func:`unsafe_bialgebra_op`"""
     matches = match_bialgebra_op(g)
     if matches is None: return False
     return unsafe_bialgebra_op(g, matches)
 
-def safe_apply_bialgebra_op(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def safe_apply_bialgebra_op(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_bialgebra_op` on the input vertices and if any matches are found runs :func:`unsafe_bialgebra_op`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_bialgebra_op(g, checked_vertices)
@@ -205,11 +203,12 @@ def safe_apply_bialgebra_op(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     return unsafe_bialgebra_op(g, matches)
 
 
-def match_bialgebra_op(g: BaseGraph[VT,ET],
-        vertices: Optional[List[VT]]=None,
-        vertex_type: Optional[Tuple[VertexType, VertexType]] = None,
-        edge_type: Optional[EdgeType] = None
-        ) -> Optional[Tuple[List[VT], List[VT]]]:
+def match_bialgebra_op(
+        g: BaseGraph[VT, ET],
+        vertices: list[VT] | None = None,
+        vertex_type: tuple[VertexType, VertexType] | None = None,
+        edge_type: EdgeType | None = None
+) -> tuple[list[VT], list[VT]] | None:
     if vertices is not None: candidates = set(vertices)
     else: candidates = g.vertex_set()
 
@@ -243,19 +242,20 @@ def match_bialgebra_op(g: BaseGraph[VT,ET],
                 return None
     return type1_vertices, type2_vertices
 
-def is_bialg_op_match(g: BaseGraph[VT,ET],vertices: list[VT]) -> bool:
+def is_bialg_op_match(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Checks if the given vertices form a valid match for the bialgebra operation."""
     match = match_bialgebra_op(g, vertices)
     return match is not None
 
-def unsafe_bialgebra_op(g: BaseGraph[VT,ET],
-        matches: Tuple[List[VT], List[VT]],
-        edge_type: Optional[EdgeType] = EdgeType.SIMPLE
-        ) -> bool:
+def unsafe_bialgebra_op(
+    g: BaseGraph[VT, ET],
+    matches: tuple[list[VT], list[VT]],
+    edge_type: EdgeType | None = EdgeType.SIMPLE
+) -> bool:
     """Applies the bialgebra rule to a connected pair of Z and X spiders in the opposite direction"""
-    def get_neighbors_and_loops(type1_vertices: List[VT], type2_vertices: List[VT]) -> Tuple[List[Tuple[VT, EdgeType]], List[EdgeType]]:
-        neighbors: List[Tuple[VT, EdgeType]] = []
-        loops: List[EdgeType] = []
+    def get_neighbors_and_loops(type1_vertices: list[VT], type2_vertices: list[VT]) -> tuple[list[tuple[VT, EdgeType]], list[EdgeType]]:
+        neighbors: list[tuple[VT, EdgeType]] = []
+        loops: list[EdgeType] = []
         for v1 in type1_vertices:
             for edge in g.incident_edges(v1):
                 edge_st = g.edge_st(edge)
@@ -290,7 +290,7 @@ def unsafe_bialgebra_op(g: BaseGraph[VT,ET],
     new_vertex1 = add_vertex_with_averages(type1_vertices, g, g.type(type2_vertices[0]))
     new_vertex2 = add_vertex_with_averages(type2_vertices, g, g.type(type1_vertices[0]))
 
-    etab: dict = defaultdict(lambda: [0, 0])
+    etab: dict[tuple[VT, VT], list[int]] = defaultdict(lambda: [0, 0])
     if edge_type == EdgeType.SIMPLE:
         etab[upair(new_vertex1, new_vertex2)] = [1, 0]
     else:

--- a/pyzx/rewrite_rules/bialgebra_rule.py
+++ b/pyzx/rewrite_rules/bialgebra_rule.py
@@ -269,12 +269,17 @@ def unsafe_bialgebra_op(g: BaseGraph[VT,ET],
                     neighbors.append((neighbor, g.edge_type(edge)))
         return neighbors, loops
 
-    def add_vertex_with_averages(vertices, g, vtype):
+    def add_vertex_with_averages(vertices: list[VT], g: BaseGraph[VT, ET], vtype: VertexType) -> VT:
         average_row = sum(g.row(v) for v in vertices) / len(vertices)
         average_qubit = sum(g.qubit(v) for v in vertices) / len(vertices)
         return g.add_vertex(vtype, average_qubit, average_row)
 
-    def update_etab(etab, new_vertex, neighbors, loops):
+    def update_etab(
+        etab: dict[tuple[VT, VT], list[int]],
+        new_vertex: VT,
+        neighbors: list[tuple[VT, EdgeType]],
+        loops: list[EdgeType]
+    ) -> None:
         for n, et in neighbors + [(new_vertex, et) for et in loops]:
             etab[upair(new_vertex, n)][0 if et == EdgeType.SIMPLE else 1] += 1
 

--- a/pyzx/rewrite_rules/color_change_rule.py
+++ b/pyzx/rewrite_rules/color_change_rule.py
@@ -31,11 +31,11 @@ __all__ = [
         'unsafe_color_change',
         'check_color_change']
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import VertexType, toggle_vertex, toggle_edge
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import VertexType, toggle_vertex, toggle_edge
 
 
-def color_change_diagram(g: BaseGraph[VT,ET]) -> bool:
+def color_change_diagram(g: BaseGraph[VT, ET]) -> bool:
     """Color-change an entire diagram by applying Hadamards to the inputs and ouputs."""
     for v in g.vertices():
         if g.type(v) == VertexType.BOUNDARY:
@@ -47,17 +47,17 @@ def color_change_diagram(g: BaseGraph[VT,ET]) -> bool:
             g.set_type(v, toggle_vertex(g.type(v)))
     return True
 
-def check_color_change(g: BaseGraph[VT,ET], v: VT) -> bool:
+def check_color_change(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Check if a vertex can be color-changed. It must be either a Z- or X- vertex"""
     if not (v in g.vertices()): return False
     return g.type(v) == VertexType.Z or g.type(v) == VertexType.X
 
-def color_change(g: BaseGraph[VT,ET], v: VT) -> bool:
+def color_change(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Color-change a vertex by applying Hadamards to all incident edges. Must be either a Z- or X- vertex"""
     if not check_color_change(g, v): return False
     return unsafe_color_change(g, v)
 
-def unsafe_color_change(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_color_change(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Color-change a vertex by applying Hadamards to all incident edges. Must be either a Z- or X- vertex
     NOTE: does not check if a vertex can be color-changed."""
 

--- a/pyzx/rewrite_rules/copy_rule.py
+++ b/pyzx/rewrite_rules/copy_rule.py
@@ -29,16 +29,15 @@ __all__ = ['check_copy',
            'copy',
            'unsafe_copy',]
 
-from typing import Optional
-from pyzx.utils import EdgeType, VertexType, toggle_vertex, vertex_is_zx, is_standard_hbox
+from ..utils import EdgeType, VertexType, toggle_vertex, vertex_is_zx, is_standard_hbox
 
-from pyzx.graph.base import BaseGraph, ET, VT
+from ..graph.base import BaseGraph, ET, VT
 
 
 def check_copy(
-        g: BaseGraph[VT,ET],
-        v: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT
+) -> bool:
     """Checks if input is an arity-1 spider (with a 0 or pi phase) that can be copied through its neighbor."""
 
     if not (v in g.vertices()): return False
@@ -56,7 +55,7 @@ def check_copy(
 
     if not vertex_is_zx(tv): return False
 
-    copy_type: Optional[VertexType]  = check_copy_zx(g, v, w)
+    copy_type: VertexType | None  = check_copy_zx(g, v, w)
     if copy_type is not None: return True
 
     copy_type = check_copy_h(g, v, w)
@@ -66,9 +65,10 @@ def check_copy(
 
 
 def check_copy_zx(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT) -> Optional[VertexType]:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> VertexType | None:
     """Checks if the two given vertices are zx spiders and if v can be copied through its neighbor."""
     tv = g.types()[v]
     tw = g.types()[w]
@@ -86,9 +86,10 @@ def check_copy_zx(
 
 
 def check_copy_h(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT) -> Optional[VertexType]:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> VertexType | None:
     """Checks if the w is a H-box and if v can be copied through its neighbor."""
     tv = g.types()[v]
     tw = g.types()[w]
@@ -123,7 +124,7 @@ def check_copy_h(
     else : return None
 
 
-def copy(g: BaseGraph[VT,ET], v: VT) -> bool:
+def copy(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks if the given vertex can be copied through its neighbor, and then applies the rule"""
     match: bool
     if check_copy(g, v):
@@ -133,9 +134,9 @@ def copy(g: BaseGraph[VT,ET], v: VT) -> bool:
 
 
 def unsafe_copy(
-        g: BaseGraph[VT,ET],
-        v: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT
+) -> bool:
     """Copy arity-1 spider through their neighbor."""
     rem = []
     types = g.types()
@@ -147,7 +148,7 @@ def unsafe_copy(
 
     rem.append(v)
 
-    copy_type: Optional[VertexType]  = check_copy_zx(g, v, w)
+    copy_type: VertexType | None  = check_copy_zx(g, v, w)
     if copy_type is None: copy_type = check_copy_h(g, v, w)
 
     if copy_type == VertexType.BOUNDARY:
@@ -181,5 +182,3 @@ def unsafe_copy(
 
     g.remove_vertices(rem)
     return True
-
-

--- a/pyzx/rewrite_rules/euler_rule.py
+++ b/pyzx/rewrite_rules/euler_rule.py
@@ -31,8 +31,8 @@ __all__ = ['check_hadamard_edge',
 
 
 from fractions import Fraction
-from pyzx.utils import EdgeType, VertexType, vertex_is_zx, toggle_vertex
-from pyzx.graph.base import BaseGraph, VT, ET, upair
+from ..utils import EdgeType, VertexType, vertex_is_zx, toggle_vertex
+from ..graph.base import BaseGraph, VT, ET, upair
 
 
 def check_hadamard_edge(g: BaseGraph[VT, ET], v:VT, w:VT) -> bool:

--- a/pyzx/rewrite_rules/fuse_1_FE_rule.py
+++ b/pyzx/rewrite_rules/fuse_1_FE_rule.py
@@ -50,12 +50,10 @@ __all__ = [
     'unsafe_unfuse_1_FE'
 ]
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.rewrite_rules import (
-    fuse as _fuse,
-)
-from pyzx.utils import is_pauli, VertexType
-from pyzx.rewrite_rules.fuse_rule import check_fuse
+from ..graph.base import BaseGraph, VT, ET
+from ..rewrite_rules import fuse as _fuse
+from ..utils import is_pauli, VertexType
+from ..rewrite_rules.fuse_rule import check_fuse
 
 
 def check_fuse_1_FE(g: BaseGraph[VT, ET], v: VT) -> bool:

--- a/pyzx/rewrite_rules/fuse_FE_rules.py
+++ b/pyzx/rewrite_rules/fuse_FE_rules.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-This module contains the implementation of the fault-equivalent fusion rules that fuse multiple spiders into a single spider. 
+This module contains the implementation of the fault-equivalent fusion rules that fuse multiple spiders into a single spider.
 
 The check function returns a boolean indicating whether the rule can be applied.
 The safe version of the applier will automatically call the basic checker, while the unsafe version
@@ -59,13 +59,11 @@ __all__ = [
     'is_fuse_n_match'
 ]
 
-from typing import Optional, List
-
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import VertexType, EdgeType, is_pauli
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import VertexType, EdgeType, is_pauli
 
 
-def match_fuse_4_FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> Optional[List[VT]]:
+def match_fuse_4_FE(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[VT] | None:
     """Checks if the fuse-4 rule can be applied to the given vertex set"""
     if vertices is not None: candidates = vertices
     else: candidates = list(g.vertex_set())
@@ -73,26 +71,26 @@ def match_fuse_4_FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> O
     if len(candidates) != len(set(candidates)):
         return None  # duplicates are not allowed
 
-    if not len(candidates) == 4: 
+    if not len(candidates) == 4:
         return None
 
-    if not all(v in g.vertices() for v in candidates): 
+    if not all(v in g.vertices() for v in candidates):
         return None
-    
-    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates): 
+
+    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates):
         return None
-    
+
     for v in candidates:
         neighs = list(g.neighbors(v))
         neighsinsquare = [w for w in neighs if w in candidates]
-        if not (len(neighs) == 3 and len(neighsinsquare) == 2): 
+        if not (len(neighs) == 3 and len(neighsinsquare) == 2):
             return None
-        if not all(g.num_edges(v, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs): 
+        if not all(g.num_edges(v, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs):
             return None
         if not all(g.num_edges(v, z, EdgeType.HADAMARD) == 0 for z in neighsinsquare):
             return None
 
-    return candidates  
+    return candidates
 
 def unsafe_fuse_4_FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Applies the fusion-4 rule to 4 connected spiders of the same type in a square configuration"""
@@ -115,46 +113,46 @@ def safe_fuse_4_FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     if matches is None: return False
     return unsafe_fuse_4_FE(g, matches)
 
-def simp_fuse_4_FE(g: BaseGraph[VT,ET]) -> bool:
+def simp_fuse_4_FE(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_fuse_4_FE` on the entire graph and if any matches are found runs :func:`unsafe_fuse_4_FE`"""
     matches = match_fuse_4_FE(g)
     if matches is None: return False
     return unsafe_fuse_4_FE(g, matches)
 
-def is_fuse_4_match(g: BaseGraph[VT,ET], vertices: list[VT]) -> bool:
+def is_fuse_4_match(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Checks if the given vertices form a valid match for the fuse 4 operation."""
     match = match_fuse_4_FE(g, vertices)
     return match is not None
 
-def match_fuse_5_FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> Optional[List[VT]]:
+def match_fuse_5_FE(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[VT] | None:
     """Checks if the fuse-5 rule can be applied to the given vertex set"""
     if vertices is not None: candidates = vertices
     else: candidates = list(g.vertex_set())
 
-    if not (len(candidates) == 5 and len(candidates) == len(set(candidates))): 
+    if not (len(candidates) == 5 and len(candidates) == len(set(candidates))):
         return None
 
-    if not all(v in g.vertices() for v in candidates): 
+    if not all(v in g.vertices() for v in candidates):
         return None
-    
-    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates): 
+
+    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates):
         return None
-    
+
     #start traversal from the first vertex
     checked = []
     neighs0 = list(g.neighbors(candidates[0]))
     neighsincycle0 = [w for w in neighs0 if w in candidates]
 
     #checks for first vertex
-    if not (len(neighs0) == 3 and len(neighsincycle0) == 2): 
+    if not (len(neighs0) == 3 and len(neighsincycle0) == 2):
             return None
-    
-    if not all(g.num_edges(candidates[0], vertex, EdgeType.SIMPLE) == 1 for vertex in neighs0): 
+
+    if not all(g.num_edges(candidates[0], vertex, EdgeType.SIMPLE) == 1 for vertex in neighs0):
                 return None
-            
+
     if not all(g.num_edges(candidates[0], z, EdgeType.HADAMARD) == 0 for z in neighsincycle0):
             return None
-            
+
     checked.extend([candidates[0], neighsincycle0[0]])
 
     #traverse the rest of the cycle
@@ -168,7 +166,7 @@ def match_fuse_5_FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> O
             # intermediate vertices
             if not (len(neighs) == 3 and len(visited_neighbors) == 1 and len(neighsincycle) == 2):
                 return None
-            
+
             unvisited_cycle_neighbor = [v for v in neighsincycle if v not in visited_neighbors]
             checked.append(unvisited_cycle_neighbor[0])
 
@@ -176,14 +174,14 @@ def match_fuse_5_FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> O
             # last vertex
             if not (len(neighs) == 3 and len(visited_neighbors) == 2 and len(neighsincycle) == 2):
                 return None
-        
-        if not all(g.num_edges(currentvertex, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs): 
+
+        if not all(g.num_edges(currentvertex, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs):
             return None
-            
+
         if not all(g.num_edges(currentvertex, z, EdgeType.HADAMARD) == 0 for z in neighsincycle):
             return None
 
-    return candidates  
+    return candidates
 
 def unsafe_fuse_5_FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Applies the fusion-5 rule to 5 connected spiders of the same type in a pentagon configuration"""
@@ -206,46 +204,46 @@ def safe_fuse_5_FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     if matches is None: return False
     return unsafe_fuse_5_FE(g, matches)
 
-def simp_fuse_5_FE(g: BaseGraph[VT,ET]) -> bool:
+def simp_fuse_5_FE(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_fuse_5_FE` on the entire graph and if any matches are found runs :func:`unsafe_fuse_5_FE`"""
     matches = match_fuse_5_FE(g)
     if matches is None: return False
     return unsafe_fuse_5_FE(g, matches)
 
-def is_fuse_5_match(g: BaseGraph[VT,ET], vertices: list[VT]) -> bool:
+def is_fuse_5_match(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Checks if the given vertices form a valid match for the fuse 5 operation."""
     match = match_fuse_5_FE(g, vertices)
     return match is not None
 
-def match_fuse_n_2FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> Optional[List[VT]]:
+def match_fuse_n_2FE(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[VT] | None:
     """Checks if the fuse-n rule can be applied to the given vertex set. Note: Only gives a match if n greater or equal than 6, otherwise fuse-4 or fuse-5 rule must be used."""
     if vertices is not None: candidates = vertices
     else: candidates = list(g.vertex_set())
 
-    if not (len(candidates) > 5 and len(candidates) == len(set(candidates))): 
+    if not (len(candidates) > 5 and len(candidates) == len(set(candidates))):
         return None
 
-    if not all(v in g.vertices() for v in candidates): 
+    if not all(v in g.vertices() for v in candidates):
         return None
-    
-    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates): 
+
+    if not all(g.type(v) == g.type(candidates[0]) and g.type(v) in (VertexType.X, VertexType.Z) and is_pauli(g.phase(v)) for v in candidates):
         return None
-    
+
     #start traversal from the first vertex
     checked = []
     neighs0 = list(g.neighbors(candidates[0]))
     neighsincycle0 = [w for w in neighs0 if w in candidates]
 
     #checks for first vertex
-    if not (len(neighs0) == 3 and len(neighsincycle0) == 2): 
+    if not (len(neighs0) == 3 and len(neighsincycle0) == 2):
             return None
-    
-    if not all(g.num_edges(candidates[0], vertex, EdgeType.SIMPLE) == 1 for vertex in neighs0): 
+
+    if not all(g.num_edges(candidates[0], vertex, EdgeType.SIMPLE) == 1 for vertex in neighs0):
                 return None
-            
+
     if not all(g.num_edges(candidates[0], z, EdgeType.HADAMARD) == 0 for z in neighsincycle0):
             return None
-            
+
     checked.extend([candidates[0], neighsincycle0[0]])
 
     #traverse the rest of the cycle
@@ -259,7 +257,7 @@ def match_fuse_n_2FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> 
             # intermediate vertices
             if not (len(neighs) == 3 and len(visited_neighbors) == 1 and len(neighsincycle) == 2):
                 return None
-            
+
             unvisited_cycle_neighbor = [v for v in neighsincycle if v not in visited_neighbors]
             checked.append(unvisited_cycle_neighbor[0])
 
@@ -267,14 +265,14 @@ def match_fuse_n_2FE(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> 
             # last vertex
             if not (len(neighs) == 3 and len(visited_neighbors) == 2 and len(neighsincycle) == 2):
                 return None
-        
-        if not all(g.num_edges(currentvertex, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs): 
+
+        if not all(g.num_edges(currentvertex, vertex, EdgeType.SIMPLE) == 1 for vertex in neighs):
             return None
-            
+
         if not all(g.num_edges(currentvertex, z, EdgeType.HADAMARD) == 0 for z in neighsincycle):
             return None
 
-    return candidates  
+    return candidates
 
 def unsafe_fuse_n_2FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Applies the fusion-n rule to n connected spiders of the same type in a cycle configuration"""
@@ -298,13 +296,13 @@ def safe_fuse_n_2FE(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     if matches is None: return False
     return unsafe_fuse_n_2FE(g, matches)
 
-def simp_fuse_n_2FE(g: BaseGraph[VT,ET]) -> bool:
+def simp_fuse_n_2FE(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_fuse_n_2FE` on the entire graph and if any matches are found runs :func:`unsafe_fuse_n_2FE`"""
     matches = match_fuse_n_2FE(g)
     if matches is None: return False
     return unsafe_fuse_n_2FE(g, matches)
 
-def is_fuse_n_match(g: BaseGraph[VT,ET], vertices: list[VT]) -> bool:
+def is_fuse_n_match(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Checks if the given vertices form a valid match for the fuse n operation."""
     match = match_fuse_n_2FE(g, vertices)
     return match is not None

--- a/pyzx/rewrite_rules/fuse_hboxes_rule.py
+++ b/pyzx/rewrite_rules/fuse_hboxes_rule.py
@@ -28,12 +28,11 @@ __all__ = ['check_connected_hboxes',
            'unsafe_fuse_hboxes']
 
 
-from typing import Dict, List, Tuple, Set
-from pyzx.utils import EdgeType, VertexType, is_standard_hbox
-from pyzx.graph.base import BaseGraph, ET, VT, upair
+from ..utils import EdgeType, VertexType, is_standard_hbox
+from ..graph.base import BaseGraph, ET, VT, upair
 
 
-def check_connected_hboxes(g: BaseGraph[VT ,ET], v: VT, w: VT) -> bool:
+def check_connected_hboxes(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Matches Hadamard-edges that are connected to H-boxes, as these can be fused,
     see the rule (HS1) of https://arxiv.org/pdf/1805.02175.pdf.
 
@@ -44,7 +43,7 @@ def check_connected_hboxes(g: BaseGraph[VT ,ET], v: VT, w: VT) -> bool:
     if not g.connected(v, w): return False
 
     e = g.edge(v, w)
-    m : Set[ET] = set()
+    m: set[ET] = set()
     ty = g.types()
 
     if g.edge_type(e) != EdgeType.HADAMARD: return False
@@ -55,17 +54,17 @@ def check_connected_hboxes(g: BaseGraph[VT ,ET], v: VT, w: VT) -> bool:
 
     return True
 
-def fuse_hboxes(g: BaseGraph[VT ,ET], v1: VT, v2: VT) -> bool:
+def fuse_hboxes(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     """Fuses two neighboring H-boxes together, if they can be fused.
         See rule (HS1) of https://arxiv.org/pdf/1805.02175.pdf."""
     if check_connected_hboxes(g, v1, v2): return unsafe_fuse_hboxes(g, v1, v2)
     return False
 
-def unsafe_fuse_hboxes(g: BaseGraph[VT ,ET], v1: VT, v2: VT) -> bool:
+def unsafe_fuse_hboxes(g: BaseGraph[VT, ET], v1: VT, v2: VT) -> bool:
     """Fuses two neighboring H-boxes together.
     See rule (HS1) of https://arxiv.org/pdf/1805.02175.pdf."""
     rem_verts = []
-    etab: Dict[Tuple[VT ,VT], List[int]] = {}
+    etab: dict[tuple[VT, VT], list[int]] = {}
 
     if not is_standard_hbox(g, v2):  # Ensure v2 is the standard one.
         v1, v2 = v2, v1
@@ -84,4 +83,3 @@ def unsafe_fuse_hboxes(g: BaseGraph[VT ,ET], v1: VT, v2: VT) -> bool:
     g.remove_isolated_vertices()
 
     return True
-

--- a/pyzx/rewrite_rules/fuse_rule.py
+++ b/pyzx/rewrite_rules/fuse_rule.py
@@ -32,18 +32,18 @@ __all__ = [
         'unsafe_fuse']
 
 
-from pyzx.utils import (get_w_io, get_z_box_label, EdgeType, VertexType,
+from ..utils import (get_w_io, get_z_box_label, EdgeType, VertexType,
                         set_z_box_label, vertex_is_w, vertex_is_z_like,
                         FloatInt)
-from typing import List, Any, Dict, Tuple
+from typing import Any
 from fractions import Fraction
 
-from pyzx.rewrite_rules.z_to_z_box_rule import unsafe_z_to_z_box
-from pyzx.graph.base import BaseGraph, VT, ET
+from ..rewrite_rules.z_to_z_box_rule import unsafe_z_to_z_box
+from ..graph.base import BaseGraph, VT, ET
 
 # Fuse spiders
 
-def check_fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def check_fuse(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Checks if two vertices can be fused. Accepts Z, X or w_input/output vertices"""
     if check_fuse_w(g, v, w):
         return True
@@ -57,12 +57,12 @@ def check_fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
         return True
     return False
 
-def fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def fuse(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Checks if two vertices can be fused and then fuses them."""
     if not check_fuse(g, v, w): return False
     return unsafe_fuse(g, v, w)
 
-def unsafe_fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def unsafe_fuse(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Fuses two vertices into one"""
     if vertex_is_w(g.type(v)):
         return unsafe_fuse_w(g, v, w)
@@ -89,7 +89,7 @@ def unsafe_fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
         g.fuse_phases(v, w)
 
 
-    etab: Dict[Tuple[VT, VT], List[int]] = dict()
+    etab: dict[tuple[VT, VT], list[int]] = {}
 
     for e in g.incident_edges(w):
         source, target = g.edge_st(e)
@@ -113,7 +113,7 @@ def unsafe_fuse(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
 
 # Fuse w
 
-def check_fuse_w(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def check_fuse_w(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Checks if two vertices are either w_input or w_output and whether they can be fused."""
     if not (v in g.vertices() and w in g.vertices()): return False
 
@@ -125,16 +125,16 @@ def check_fuse_w(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
             return True
     return False
 
-def fuse_w(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def fuse_w(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Checks and then performs W fusion on a given set of vertices."""
     if not check_fuse_w(g, v, w): return False
     return unsafe_fuse_w(g, v, w)
 
-def unsafe_fuse_w(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def unsafe_fuse_w(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Performs W fusion on a given set of vertices.
     Note: Does not check if fuse can be applied before applying the rule"""
-    rem_verts: List[VT] = []
-    etab: Dict[Tuple[VT,VT],List[int]] = dict()
+    rem_verts: list[VT] = []
+    etab: dict[tuple[VT, VT], list[int]] = {}
 
     v1_in, v1_out = get_w_io(g, v)
     v2_in, v2_out = get_w_io(g, w)
@@ -163,7 +163,7 @@ def unsafe_fuse_w(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
 
 #TODO: fix this to work with Rewrite class
 
-def unfuse(g: BaseGraph[VT,ET], m: List[Any], qubit:FloatInt=-1, row:FloatInt=-1) -> VT:
+def unfuse(g: BaseGraph[VT, ET], m: list[Any], qubit: FloatInt = -1, row: FloatInt = -1) -> VT:
     """Undoes a single spider fusion, given a match ``m``. A match is a list with 3
     elements given by::
 
@@ -194,4 +194,3 @@ def unfuse(g: BaseGraph[VT,ET], m: List[Any], qubit:FloatInt=-1, row:FloatInt=-1
         g.set_phase(v, g.phase(u))
         g.set_phase(u, 0)
     return v
-

--- a/pyzx/rewrite_rules/gadget_phasepoly_rule.py
+++ b/pyzx/rewrite_rules/gadget_phasepoly_rule.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 """
-This module contains the implementation of the gadget phasepoly rule. 
-This finds 4 groups of phase-gadgets that act on the same set of 4 vertices 
-in order to apply a rewrite based on rule R_13 of 
+This module contains the implementation of the gadget phasepoly rule.
+This finds 4 groups of phase-gadgets that act on the same set of 4 vertices
+in order to apply a rewrite based on rule R_13 of
 the paper *A Finite Presentation of CNOT-Dihedral Operators*.
 
 This rule acts on an entire graph and should only be called using the using
@@ -27,25 +27,22 @@ simplify.gadget_phasepoly_simp(g).
 __all__ = ['gadgets_phasepoly_for_simp',
            'gadgets_phasepoly_for_apply']
 
-from typing import Tuple, List, Dict, Set, FrozenSet
-from typing import Union
-
 from fractions import Fraction
 import itertools
 
-from pyzx.utils import EdgeType, VertexType
-from pyzx.graph.base import BaseGraph, VT, ET
+from ..utils import EdgeType, VertexType
+from ..graph.base import BaseGraph, VT, ET
 
 
-MatchPhasePolyType = Tuple[List[VT], Dict[FrozenSet[VT],Union[VT,Tuple[VT,VT]]]]
+MatchPhasePolyType = tuple[list[VT], dict[frozenset[VT], VT | tuple[VT, VT]]]
 
 
 
-def match_gadgets_phasepoly(g: BaseGraph[VT,ET]) -> List[MatchPhasePolyType[VT]]:
+def match_gadgets_phasepoly(g: BaseGraph[VT, ET]) -> list[MatchPhasePolyType[VT]]:
     """Finds 4 groups of phase-gadgets that act on the same set of 4 vertices in order to apply a rewrite based on
     rule R_13 of the paper *A Finite Presentation of CNOT-Dihedral Operators*."""
-    targets: Dict[VT,Set[FrozenSet[VT]]] = {}
-    gadgets: Dict[FrozenSet[VT], Tuple[VT,VT]] = {}
+    targets: dict[VT, set[frozenset[VT]]] = {}
+    gadgets: dict[frozenset[VT], tuple[VT, VT]] = {}
     inputs = g.inputs()
     outputs = g.outputs()
     for v in g.vertices():
@@ -62,7 +59,7 @@ def match_gadgets_phasepoly(g: BaseGraph[VT,ET]) -> List[MatchPhasePolyType[VT]]
             if v in targets: targets[v].add(frozenset([v]))
             else: targets[v] = {frozenset([v])}
     targets = {t:s for t,s in targets.items() if len(s)>1}
-    matches: Dict[FrozenSet[VT], Set[FrozenSet[VT]]] = {}
+    matches: dict[frozenset[VT], set[frozenset[VT]]] = {}
 
     for v1,t1 in targets.items():
         s = t1.difference(frozenset([v1]))
@@ -77,13 +74,13 @@ def match_gadgets_phasepoly(g: BaseGraph[VT,ET]) -> List[MatchPhasePolyType[VT]]
             for t in c: a.update([i for s in targets[t] for i in s if i in targets])
             for group in itertools.combinations(a.difference(c),4-len(c)):
                 gr = list(group)+list(c)
-                b: Set[FrozenSet[VT]] = set()
+                b: set[frozenset[VT]] = set()
                 for t in gr: b.update([s for s in targets[t] if s.issubset(gr)])
                 if len(b)>7:
                     matches[frozenset(gr)] = b
 
-    m: List[MatchPhasePolyType[VT]] = []
-    taken: Set[VT] = set()
+    m: list[MatchPhasePolyType[VT]] = []
+    taken: set[VT] = set()
     for groupp, gad in sorted(matches.items(), key=lambda x: len(x[1]), reverse=True):
         if taken.intersection(groupp): continue
         m.append((list(groupp), {s:(gadgets[s] if len(s)>1 else list(s)[0]) for s in gad}))
@@ -92,18 +89,19 @@ def match_gadgets_phasepoly(g: BaseGraph[VT,ET]) -> List[MatchPhasePolyType[VT]]
     return m
 
 
-def gadgets_phasepoly_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def gadgets_phasepoly_for_apply(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Dummy function, do not use"""
     return False
 
-def gadgets_phasepoly_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def gadgets_phasepoly_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_gadgets_phasepoly` and if any matches are found runs :func:`apply_gadget_phasepoly`"""
     matches = match_gadgets_phasepoly(g)
     if (len(matches)==0): return False
     return apply_gadget_phasepoly(g, matches)
 
 
-def apply_gadget_phasepoly(g: BaseGraph[VT,ET], matches: List[MatchPhasePolyType[VT]]) -> bool:
+
+def apply_gadget_phasepoly(g: BaseGraph[VT, ET], matches: list[MatchPhasePolyType[VT]]) -> bool:
     """Uses the output of :func:`match_gadgets_phasepoly` to apply a rewrite based
     on rule R_13 of the paper *A Finite Presentation of CNOT-Dihedral Operators*."""
     rs = g.rows()
@@ -117,14 +115,14 @@ def apply_gadget_phasepoly(g: BaseGraph[VT,ET], matches: List[MatchPhasePolyType
                 v2 = group[j]
                 f = frozenset({v1,v2})
                 if f in gadgets:
-                    n,v = gadgets[f] # type: ignore # complex typing situation
+                    n, v = gadgets[f] # type: ignore # complex typing situation
                     phase = phases[v]
                     if phases[n]:
                         phase = -phase
                         g.set_phase(n,0)
                 else:
-                    n = g.add_vertex(VertexType.Z,-1, rs[v2]+0.5)
-                    v = g.add_vertex(VertexType.Z,-2, rs[v2]+0.5)
+                    n = g.add_vertex(VertexType.Z, -1, rs[v2]+0.5)
+                    v = g.add_vertex(VertexType.Z, -2, rs[v2]+0.5)
                     phase = 0
                     g.add_edges([(n,v),(v1,n),(v2,n)],EdgeType.HADAMARD)
                 g.set_phase(v, phase + Fraction(3,4))
@@ -133,7 +131,7 @@ def apply_gadget_phasepoly(g: BaseGraph[VT,ET], matches: List[MatchPhasePolyType
                     v3 = group[k]
                     f = frozenset({v1,v2,v3})
                     if f in gadgets:
-                        n,v = gadgets[f] # type: ignore
+                        n, v = gadgets[f] # type: ignore
                         phase = phases[v]
                         if phases[n]:
                             phase = -phase
@@ -146,7 +144,7 @@ def apply_gadget_phasepoly(g: BaseGraph[VT,ET], matches: List[MatchPhasePolyType
                     g.set_phase(v, phase + Fraction(1,4))
         f = frozenset(group)
         if f in gadgets:
-            n,v = gadgets[f] # type: ignore
+            n, v = gadgets[f] # type: ignore
             phase = phases[v]
             if phases[n]:
                 phase = -phase

--- a/pyzx/rewrite_rules/had_edge_hbox_rule.py
+++ b/pyzx/rewrite_rules/had_edge_hbox_rule.py
@@ -28,31 +28,31 @@ __all__ = ['check_hadamard',
            'had_edge_to_hbox',
            'unsafe_had_edge_to_hbox']
 
-from pyzx.utils import EdgeType, VertexType, is_standard_hbox
-from pyzx.graph.base import BaseGraph, ET, VT
-from pyzx.rewrite_rules.euler_rule import check_hadamard_edge
+from ..utils import EdgeType, VertexType, is_standard_hbox
+from ..graph.base import BaseGraph, ET, VT
+from ..rewrite_rules.euler_rule import check_hadamard_edge
 
-def check_hadamard(g: BaseGraph[VT ,ET], v: VT) -> bool:
+def check_hadamard(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Returns whether the vertex v in graph g is a Hadamard gate."""
     if g.type(v) != VertexType.H_BOX: return False
     if not is_standard_hbox(g, v): return False
     if g.vertex_degree(v) != 2: return False
     return True
 
-def replace_hadamard(g: BaseGraph[VT ,ET], v: VT) -> bool:
+def replace_hadamard(g: BaseGraph[VT, ET], v: VT) -> bool:
     """First checks if the vertex is a H-box and then replaces it with a Hadamard edge."""
     if check_hadamard(g, v): return unsafe_replace_hadamard(g, v)
     return False
 
-def unsafe_replace_hadamard(g: BaseGraph[VT ,ET], v: VT) -> bool:
+def unsafe_replace_hadamard(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Replaces a Hadamard gate with a Hadamard edge."""
     n1 ,n2 = g.neighbors(v)
-    et1 = g.edge_type(g.edge(v ,n1))
-    et2 = g.edge_type(g.edge(v ,n2))
+    et1 = g.edge_type(g.edge(v, n1))
+    et2 = g.edge_type(g.edge(v, n2))
     if et1 == et2: # both connecting edges are HADAMARD or SIMPLE
-        g.add_edge((n1 ,n2), EdgeType.HADAMARD)
+        g.add_edge((n1, n2), EdgeType.HADAMARD)
     else:
-        g.add_edge((n1 ,n2), EdgeType.SIMPLE)
+        g.add_edge((n1, n2), EdgeType.SIMPLE)
     g.remove_vertex(v)
     g.scalar.add_power(1) # Correct for the sqrt(2) difference in H-boxes and H-edges
     return True
@@ -63,7 +63,7 @@ def had_edge_to_hbox(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     if check_hadamard_edge(g, v, w): return unsafe_had_edge_to_hbox(g, v, w)
     return False
 
-def unsafe_had_edge_to_hbox(g: BaseGraph[VT ,ET], v: VT, w: VT) -> bool:
+def unsafe_had_edge_to_hbox(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Converts a Hadamard edge to a Hadamard gate.
     Note that while this works with multigraphs, it will put the new H-box in the middle of the vertices,
     so that the diagram might look wrong.
@@ -91,5 +91,3 @@ def unsafe_had_edge_to_hbox(g: BaseGraph[VT ,ET], v: VT, w: VT) -> bool:
         g.set_qubit(h, q)
     g.set_row(h, (rs + rt) / 2)
     return True
-
-

--- a/pyzx/rewrite_rules/hbox_cancel_rule.py
+++ b/pyzx/rewrite_rules/hbox_cancel_rule.py
@@ -30,8 +30,8 @@ __all__ = ['check_hbox_cancel',
            'hbox_cancel',
            'unsafe_hbox_cancel']
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import EdgeType, VertexType, is_standard_hbox
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import EdgeType, VertexType, is_standard_hbox
 
 
 def check_hbox_cancel(g: BaseGraph[VT, ET], v: VT) -> bool:

--- a/pyzx/rewrite_rules/hbox_not_remove_rule.py
+++ b/pyzx/rewrite_rules/hbox_not_remove_rule.py
@@ -34,7 +34,7 @@ from pyzx.utils import EdgeType, VertexType, is_standard_hbox
 from pyzx.graph.base import BaseGraph, ET, VT, upair
 
 
-def is_NOT_gate(g, v, n1, n2):
+def is_NOT_gate(g: BaseGraph[VT, ET], v: VT, n1: VT, n2: VT) -> bool:
     """Returns whether the vertex v in graph g is a NOT gate between its neighbours n1 and n2."""
     return (
         (
@@ -49,11 +49,7 @@ def is_NOT_gate(g, v, n1, n2):
     )
 
 
-def check_hbox_parallel_not(
-        g: BaseGraph[VT,ET],
-        h: VT,
-        n: VT
-        ) -> bool:
+def check_hbox_parallel_not(g: BaseGraph[VT,ET], h: VT, n: VT) -> bool:
     """Finds H-boxes that are connected to a Z-spider both directly and via a NOT.
     :param g: Graph to check.
     :param h: H-box to check.

--- a/pyzx/rewrite_rules/hbox_not_remove_rule.py
+++ b/pyzx/rewrite_rules/hbox_not_remove_rule.py
@@ -29,9 +29,8 @@ __all__ = ['check_hbox_parallel_not',
            'unsafe_hbox_parallel_not_remove']
 
 
-from typing import Dict, List, Tuple
-from pyzx.utils import EdgeType, VertexType, is_standard_hbox
-from pyzx.graph.base import BaseGraph, ET, VT, upair
+from ..utils import EdgeType, VertexType, is_standard_hbox
+from ..graph.base import BaseGraph, ET, VT, upair
 
 
 def is_NOT_gate(g: BaseGraph[VT, ET], v: VT, n1: VT, n2: VT) -> bool:
@@ -49,7 +48,7 @@ def is_NOT_gate(g: BaseGraph[VT, ET], v: VT, n1: VT, n2: VT) -> bool:
     )
 
 
-def check_hbox_parallel_not(g: BaseGraph[VT,ET], h: VT, n: VT) -> bool:
+def check_hbox_parallel_not(g: BaseGraph[VT, ET], h: VT, n: VT) -> bool:
     """Finds H-boxes that are connected to a Z-spider both directly and via a NOT.
     :param g: Graph to check.
     :param h: H-box to check.
@@ -74,20 +73,20 @@ def check_hbox_parallel_not(g: BaseGraph[VT,ET], h: VT, n: VT) -> bool:
     return True
 
 
-def hbox_parallel_not_remove(g: BaseGraph[VT,ET], h: VT, n: VT) -> bool:
+def hbox_parallel_not_remove(g: BaseGraph[VT, ET], h: VT, n: VT) -> bool:
     """If a Z-spider is connected to an H-box via a regular wire and a NOT, then they disconnect, and the H-box is turned into a Z-spider."""
     if check_hbox_parallel_not(g,h,n): return unsafe_hbox_parallel_not_remove(g,h,n)
     return False
 
 
-def unsafe_hbox_parallel_not_remove(g: BaseGraph[VT,ET], h: VT, n: VT) -> bool:
+def unsafe_hbox_parallel_not_remove(g: BaseGraph[VT, ET], h: VT, n: VT) -> bool:
     """Disconnects the Z-spider and H-box, and the H-box is turned into a Z-spider.
     :param g: Graph to check.
     :param h: H-box to check.
     :param n: NOT connecting hbox and Z-spider."""
 
-    rem = []
-    etab: Dict[Tuple[VT,VT], List[int]] = {}
+    rem: list[VT] = []
+    etab: dict[tuple[VT, VT], list[int]] = {}
     types = g.types()
 
     rem.append(h)

--- a/pyzx/rewrite_rules/hopf_rule.py
+++ b/pyzx/rewrite_rules/hopf_rule.py
@@ -29,11 +29,10 @@ __all__ = ['check_hopf',
            'hopf',
            'unsafe_hopf']
 
-from typing import Tuple, List, Dict
-from pyzx.utils import EdgeType, vertex_is_z_like, vertex_is_zx_like
-from pyzx.graph.base import BaseGraph, VT, ET
+from ..utils import EdgeType, vertex_is_z_like, vertex_is_zx_like
+from ..graph.base import BaseGraph, VT, ET
 
-MatchHopfType = Tuple[VT, VT, EdgeType]
+MatchHopfType = tuple[VT, VT, EdgeType]
 
 
 def check_hopf(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
@@ -71,8 +70,8 @@ def hopf(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
 def unsafe_hopf(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Removes parallel edges between the given vertices.
     """
-    etab: Dict[Tuple[VT, VT], List[int]] = dict()
-    rem_edges: List[ET] = []
+    etab: dict[tuple[VT, VT], list[int]] = {}
+    rem_edges: list[ET] = []
 
     # Determine the edge type to remove from the spider colours, matching
     # the logic in `check_hopf`. Looking up the type via `g.edge(v, w)` is

--- a/pyzx/rewrite_rules/hpivot_rule.py
+++ b/pyzx/rewrite_rules/hpivot_rule.py
@@ -24,30 +24,29 @@ __all__ = ['hpivot',
 
 from fractions import Fraction
 from itertools import combinations
-from typing import List, Tuple, Optional
-from pyzx.utils import VertexType, toggle_edge, FractionLike, FloatInt, is_standard_hbox
-from pyzx.graph.base import BaseGraph, ET, VT
+from ..utils import VertexType, toggle_edge, FractionLike, FloatInt, is_standard_hbox
+from ..graph.base import BaseGraph, ET, VT
 
 
-hpivot_match_output = List[Tuple[
+hpivot_match_output = list[tuple[
     VT,
     VT,
     VT,
-    List[VT],
-    List[VT],
-    List[List[VT]],
-    List[Tuple[FractionLike, List[VT]]]
+    list[VT],
+    list[VT],
+    list[list[VT]],
+    list[tuple[FractionLike, list[VT]]]
 ]]
 
 
 
-def simp_hpivot(g: BaseGraph[VT,ET]) -> bool:
+def simp_hpivot(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_hpivot` and if any matches are found runs :func:`unsafe_hpivot`"""
     matches = match_hpivot(g)
     if len(matches) == 0: return False
     return unsafe_hpivot(g, matches)
 
-def hpivot(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def hpivot(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Dummy function, may have undefined behavior"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_hpivot(g, checked_vertices)
@@ -56,9 +55,7 @@ def hpivot(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
 
 
 # hpivot
-def match_hpivot(
-        g: BaseGraph[VT, ET], vertices: Optional[List[VT]] = None
-) -> hpivot_match_output:
+def match_hpivot(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> hpivot_match_output:
     """Finds a matching of the hyper-pivot rule. Note this currently assumes
     hboxes don't have phases.
 

--- a/pyzx/rewrite_rules/lcomp_rule.py
+++ b/pyzx/rewrite_rules/lcomp_rule.py
@@ -30,18 +30,16 @@ __all__ = [
         'unsafe_lcomp']
 
 
-from typing import Tuple, List, Dict
-
 from fractions import Fraction
 
-from pyzx.utils import EdgeType, VertexType
-from pyzx.graph.base import BaseGraph, VT, ET
+from ..utils import EdgeType, VertexType
+from ..graph.base import BaseGraph, VT, ET
 
 
 def check_lcomp(
-        g: BaseGraph[VT,ET],
-        v: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT
+) -> bool:
     """Checks if a given vertex can be simplified using the local complementation rule.
 
     :param g: An instance of a ZX-graph.
@@ -70,7 +68,7 @@ def check_lcomp(
     return True
 
 
-def lcomp(g: BaseGraph[VT,ET], v: VT) -> bool:
+def lcomp(g: BaseGraph[VT, ET], v: VT) -> bool:
     """First checks if the rule can be applied, then performs a local complementation based rewrite rule on the given graph and vertex.
     See "Graph Theoretic Simplification of Quantum Circuits using the ZX calculus" (arXiv:1902.03178)
     for more details on the rewrite"""
@@ -79,12 +77,12 @@ def lcomp(g: BaseGraph[VT,ET], v: VT) -> bool:
     return False
 
 
-def unsafe_lcomp(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_lcomp(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Performs a local complementation based rewrite rule on the given graph with the
     given vertex. See "Graph Theoretic Simplification of Quantum Circuits using the ZX calculus" (arXiv:1902.03178)
     for more details on the rewrite"""
-    etab: Dict[Tuple[VT,VT],List[int]] = dict()
-    rem: List[VT] = []
+    etab: dict[tuple[VT,VT], list[int]] = {}
+    rem: list[VT] = []
 
     vn = list(g.neighbors(v))
 

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -26,34 +26,32 @@ Boolean parameter into a non-Boolean phase), call :func:`merge_phase_gadgets_for
 ``simplify.gadget_simp`` wrapper cannot forward this keyword.
 """
 
-from typing import Tuple, List, Dict, FrozenSet
-from typing import Optional
 from fractions import Fraction
 
-from pyzx.utils import FractionLike, phase_is_pauli, push_pauli_axel
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.symbolic import Poly
+from ..utils import FractionLike, phase_is_pauli, push_pauli_axel
+from ..graph.base import BaseGraph, VT, ET
+from ..symbolic import Poly
 
 
 __all__ = ['merge_phase_gadgets_for_simp',
         'merge_phase_gadgets_for_apply']
 
-MatchGadgetType = Tuple[VT,VT,FractionLike,List[VT],List[VT]]
+MatchGadgetType = tuple[VT, VT, FractionLike, list[VT], list[VT]]
 
-def merge_phase_gadgets_for_simp(g: BaseGraph[VT,ET], apply_to_boolean_axels: bool = False) -> bool:
+def merge_phase_gadgets_for_simp(g: BaseGraph[VT, ET], apply_to_boolean_axels: bool = False) -> bool:
     """Runs :func:`match_phase_gadgets` and if any matches are found runs :func:`merge_phase_gadgets`"""
     matches = match_phase_gadgets(g, apply_to_boolean_axels=apply_to_boolean_axels)
     if len(matches) == 0: return False
     return merge_phase_gadgets(g, matches)
 
-def merge_phase_gadgets_for_apply(g: BaseGraph[VT,ET], vertices: List[VT], apply_to_boolean_axels: bool = False) -> bool:
+def merge_phase_gadgets_for_apply(g: BaseGraph[VT, ET], vertices: list[VT], apply_to_boolean_axels: bool = False) -> bool:
     """Runs :func:`match_phase_gadgets` on the input vertices and if any matches are found runs :func:`merge_phase_gadgets`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_phase_gadgets(g, checked_vertices, apply_to_boolean_axels=apply_to_boolean_axels)
     if len(matches) == 0: return False
     return merge_phase_gadgets(g, matches)
 
-def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None, apply_to_boolean_axels: bool = False) -> List[MatchGadgetType[VT]]:
+def match_phase_gadgets(g: BaseGraph[VT, ET], vertices: list[VT] | None = None, apply_to_boolean_axels: bool = False) -> list[MatchGadgetType[VT]]:
     """Determines which phase gadgets act on the same vertices, so that they can be fused together.
 
     :param g: An instance of a ZX-graph.
@@ -68,8 +66,8 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None, a
 
     phases = g.phases()
 
-    parities: Dict[FrozenSet[VT], List[VT]] = dict()
-    gadgets: Dict[VT,VT] = dict()
+    parities: dict[frozenset[VT], list[VT]] = {}
+    gadgets: dict[VT, VT] = {}
     inputs = g.inputs()
     outputs = g.outputs()
     # First we find all the phase-gadgets, and the list of vertices they act on
@@ -89,7 +87,7 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None, a
             if par in parities: parities[par].append(n)
             else: parities[par] = [n]
 
-    m: List[MatchGadgetType[VT]] = []
+    m: list[MatchGadgetType[VT]] = []
     for par, gad in parities.items():
         # Skip parity groups whose axels include a symbolic Boolean Poly unless the
         # caller opted in: absorbing that axel here would convert its Boolean parameter
@@ -128,9 +126,9 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None, a
             m.append((v, n, totphase, gad, [gadgets[n] for n in gad]))
     return m
 
-def merge_phase_gadgets(g: BaseGraph[VT,ET], matches: List[MatchGadgetType[VT]]) -> bool:
+def merge_phase_gadgets(g: BaseGraph[VT, ET], matches: list[MatchGadgetType[VT]]) -> bool:
     """Given the output of :func:``match_phase_gadgets``, removes phase gadgets that act on the same set of targets."""
-    rem: List[VT] = []
+    rem: list[VT] = []
 
 
     for v, n, phase, othergadgets, othertargets in matches:
@@ -145,4 +143,3 @@ def merge_phase_gadgets(g: BaseGraph[VT,ET], matches: List[MatchGadgetType[VT]])
 
     g.remove_vertices(rem)
     return True
-

--- a/pyzx/rewrite_rules/par_hbox_rule.py
+++ b/pyzx/rewrite_rules/par_hbox_rule.py
@@ -32,26 +32,25 @@ __all__ = ['check_par_hbox_for_simp',
            'par_hbox_avg',]
 
 
-from typing import Dict, List, Tuple, Optional, Set, FrozenSet
-from pyzx.utils import EdgeType, VertexType, hbox_has_complex_label, get_h_box_label, set_h_box_label
-from pyzx.graph.base import BaseGraph, ET, VT
+from ..utils import EdgeType, VertexType, hbox_has_complex_label, get_h_box_label, set_h_box_label
+from ..graph.base import BaseGraph, ET, VT
 
 
 ## Multiply rule:
 
 
-def check_par_hbox_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def check_par_hbox_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox` and returns whether any matches were found."""
     matches = match_par_hbox(g)
     return len(matches) > 0
 
-def simp_par_hbox(g: BaseGraph[VT,ET]) -> bool:
+def simp_par_hbox(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox` and if any matches are found runs :func:`unsafe_par_hbox`"""
     matches = match_par_hbox(g)
     if len(matches) == 0: return False
     return unsafe_par_hbox(g, matches)
 
-def par_hbox(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def par_hbox(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_par_hbox` on given vertices and if any matches are found runs :func:`unsafe_par_hbox`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_par_hbox(g, checked_vertices)
@@ -59,17 +58,15 @@ def par_hbox(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     return unsafe_par_hbox(g, matches)
 
 
-TYPE_MATCH_PAR_HBOX = Tuple[List[VT],List[VT],List[VT]]
+TYPE_MATCH_PAR_HBOX = tuple[list[VT], list[VT], list[VT]]
 
-def match_par_hbox(
-        g: BaseGraph[VT, ET],
-        vertices: Optional[List[VT]] = None) -> List[TYPE_MATCH_PAR_HBOX]:
+def match_par_hbox(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[TYPE_MATCH_PAR_HBOX]:
     """Matches sets of H-boxes that are connected in parallel (via optional NOT gates)
     to the same white spiders."""
     if vertices is not None: candidates = set(vertices)
     else: candidates = g.vertex_set()
 
-    groupings: Dict[Tuple[FrozenSet[VT], FrozenSet[VT]], Tuple[List[VT], List[VT], List[VT]]] = dict()
+    groupings: dict[tuple[frozenset[VT], frozenset[VT]], tuple[list[VT], list[VT], list[VT]]] = {}
     ty = g.types()
     for h in candidates:
         if ty[h] != VertexType.H_BOX: continue
@@ -114,15 +111,15 @@ def match_par_hbox(
         else:
             groupings[group] = ([h], NOTs, [])
 
-    m = []
+    m: list[TYPE_MATCH_PAR_HBOX] = []
     for (n_r, n_N), (hs, firstNOTs, NOTs) in groupings.items():
         if len(hs) < 2: continue
         m.append((hs, firstNOTs, NOTs))
     return m
 
-def unsafe_par_hbox(g: BaseGraph[VT, ET], matches: List[TYPE_MATCH_PAR_HBOX]) -> bool:
+def unsafe_par_hbox(g: BaseGraph[VT, ET], matches: list[TYPE_MATCH_PAR_HBOX]) -> bool:
     """Implements the `multiply rule' (M) from https://arxiv.org/abs/1805.02175"""
-    rem_verts = []
+    rem_verts: list[VT] = []
     for hs, firstNOTs, NOTs in matches:
         p = sum(g.phase(h) for h in hs) % 2
         rem_verts.extend(hs[1:])
@@ -140,18 +137,18 @@ def unsafe_par_hbox(g: BaseGraph[VT, ET], matches: List[TYPE_MATCH_PAR_HBOX]) ->
 
 ## Intro rule:
 
-def check_par_hbox_intro_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def check_par_hbox_intro_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox_intro` and returns whether any matches were found."""
     matches = match_par_hbox_intro(g)
     return len(matches) != 0
 
-def simp_par_hbox_intro(g: BaseGraph[VT,ET]) -> bool:
+def simp_par_hbox_intro(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox_intro` and if any matches are found runs :func:`unsafe_par_hbox_intro`"""
     matches = match_par_hbox_intro(g)
     if len(matches) == 0: return False
     return unsafe_par_hbox_intro(g, matches)
 
-def par_hbox_intro(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def par_hbox_intro(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_par_hbox_intro` on given vertices and if any matches are found runs :func:`unsafe_par_hbox_intro`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_par_hbox_intro(g, checked_vertices)
@@ -159,14 +156,14 @@ def par_hbox_intro(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     return unsafe_par_hbox_intro(g, matches)
 
 
-TYPE_MATCH_PAR_HBOX_INTRO = Tuple[VT, VT, VT, List[VT], Set[VT]]
-def match_par_hbox_intro(g: BaseGraph[VT, ET], vertices: Optional[List[VT]]=None) -> List[TYPE_MATCH_PAR_HBOX_INTRO]:
+TYPE_MATCH_PAR_HBOX_INTRO = tuple[VT, VT, VT, list[VT], set[VT]]
+def match_par_hbox_intro(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[TYPE_MATCH_PAR_HBOX_INTRO]:
     """Matches sets of H-boxes that are connected in parallel (via optional NOT gates)
     to the same white spiders, but with just one NOT different, so that the Intro rule can be applied there."""
     if vertices is not None: candidates = set(vertices)
     else: candidates = g.vertex_set()
 
-    groupings: Dict[FrozenSet[VT], List[Tuple[VT, List[VT], Set[VT], Set[VT], Set[VT]]]] = dict()
+    groupings: dict[frozenset[VT], list[tuple[VT, list[VT], set[VT], set[VT], set[VT]]]] = {}
     ty = g.types()
     for h in candidates:
         if ty[h] != VertexType.H_BOX: continue
@@ -243,7 +240,7 @@ def match_par_hbox_intro(g: BaseGraph[VT, ET], vertices: Optional[List[VT]]=None
 
 
 
-def unsafe_par_hbox_intro(g: BaseGraph[VT, ET], matches: List[TYPE_MATCH_PAR_HBOX_INTRO]) -> bool:
+def unsafe_par_hbox_intro(g: BaseGraph[VT, ET], matches: list[TYPE_MATCH_PAR_HBOX_INTRO]) -> bool:
     """Removes an H-box according to the Intro rule (See Section 3.2 of arxiv:2103.06610)."""
     rem_verts = []
     rem_edges = []
@@ -264,18 +261,18 @@ def unsafe_par_hbox_intro(g: BaseGraph[VT, ET], matches: List[TYPE_MATCH_PAR_HBO
 
 ## Average rule:
 
-def check_par_hbox_avg_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def check_par_hbox_avg_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox_avg` and returns whether any matches were found."""
     matches = match_par_hbox_avg(g)
     return len(matches) > 0
 
-def simp_par_hbox_avg(g: BaseGraph[VT,ET]) -> bool:
+def simp_par_hbox_avg(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_par_hbox_avg` and if any matches are found runs :func:`unsafe_par_hbox_avg`."""
     matches = match_par_hbox_avg(g)
     if len(matches) == 0: return False
     return unsafe_par_hbox_avg(g, matches)
 
-def par_hbox_avg(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def par_hbox_avg(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_par_hbox_avg` on given vertices and if any matches are found runs :func:`unsafe_par_hbox_avg`."""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_par_hbox_avg(g, checked_vertices)
@@ -283,11 +280,11 @@ def par_hbox_avg(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     return unsafe_par_hbox_avg(g, matches)
 
 
-TYPE_MATCH_PAR_HBOX_AVG = Tuple[VT, VT, VT]
+TYPE_MATCH_PAR_HBOX_AVG = tuple[VT, VT, VT]
 
 def match_par_hbox_avg(
         g: BaseGraph[VT, ET],
-        vertices: Optional[List[VT]] = None) -> List[TYPE_MATCH_PAR_HBOX_AVG]:
+        vertices: list[VT] | None = None) -> list[TYPE_MATCH_PAR_HBOX_AVG]:
     """Matches pairs of H-boxes connected through a NOT gate (degree-2 spider with
     phase pi) that share the same neighbourhood: Z-spiders via SIMPLE edges and
     X-spiders via HADAMARD edges.
@@ -300,17 +297,17 @@ def match_par_hbox_avg(
     else: candidates = g.vertex_set()
 
     ty = g.types()
-    matched: Set[VT] = set()
-    matches: List[TYPE_MATCH_PAR_HBOX_AVG] = []
+    matched: set[VT] = set()
+    matches: list[TYPE_MATCH_PAR_HBOX_AVG] = []
 
     for h in candidates:
         if ty[h] != VertexType.H_BOX: continue
         if h in matched: continue
 
         suitable = True
-        neighbors_regular: Set[VT] = set()
-        partner: Optional[VT] = None
-        not_gate: Optional[VT] = None
+        neighbors_regular: set[VT] = set()
+        partner: VT | None = None
+        not_gate: VT | None = None
 
         for v in g.neighbors(h):
             e = g.edge(v, h)
@@ -363,7 +360,7 @@ def match_par_hbox_avg(
         if partner in matched: continue
 
         # Verify the partner H-box has the same regular neighbours.
-        partner_regular: Set[VT] = set()
+        partner_regular: set[VT] = set()
         partner_ok = True
         for v in g.neighbors(partner):
             if v == not_gate: continue
@@ -394,14 +391,14 @@ def match_par_hbox_avg(
     return matches
 
 
-def unsafe_par_hbox_avg(g: BaseGraph[VT, ET], matches: List[TYPE_MATCH_PAR_HBOX_AVG]) -> bool:
+def unsafe_par_hbox_avg(g: BaseGraph[VT, ET], matches: list[TYPE_MATCH_PAR_HBOX_AVG]) -> bool:
     """Implements the average rule (A) from https://arxiv.org/abs/1805.02175.
 
     Replaces two H-boxes connected through a NOT gate with a single H-box
     whose label is the average of the two original labels. Multiplies the
     scalar by 2.
     """
-    rem_verts: List[VT] = []
+    rem_verts: list[VT] = []
     for h1, h2, not_gate in matches:
         a = get_h_box_label(g, h1)
         b = get_h_box_label(g, h2)

--- a/pyzx/rewrite_rules/pi_commute_rule.py
+++ b/pyzx/rewrite_rules/pi_commute_rule.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -29,10 +29,10 @@ __all__ = [
         'pi_commute',
         'unsafe_pi_commute',]
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.rewrite_rules.color_change_rule import color_change_diagram
+from ..graph.base import BaseGraph, VT, ET
+from ..rewrite_rules.color_change_rule import color_change_diagram
 
-from pyzx.utils import EdgeType, VertexType, vertex_is_zx
+from ..utils import EdgeType, VertexType, vertex_is_zx
 
 
 

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -43,25 +43,23 @@ __all__ = [
         ]
 
 
-from typing import Tuple, List, Dict, Set, Optional
 
 from collections import Counter
-from fractions import Fraction
 
-from pyzx.utils import VertexType, EdgeType, phase_is_pauli, phase_is_clifford
-from pyzx.graph.base import BaseGraph, VT, ET
+from ..utils import VertexType, EdgeType, phase_is_pauli, phase_is_clifford
+from ..graph.base import BaseGraph, VT, ET
 
-MatchPivotType = Tuple[Tuple[VT,VT],Tuple[List[VT],List[VT]]]
+MatchPivotType = tuple[tuple[VT, VT], tuple[list[VT], list[VT]]]
 
 
 def boundary_list_for_vertex(
-        g: BaseGraph[VT,ET],
-        v0: VT
-) -> Optional[List[VT]]:
+    g: BaseGraph[VT, ET],
+    v0: VT
+) -> list[VT] | None:
     """Returns the list of boundary vertices for a given vertex."""
     types = g.types()
     v0n = list(g.neighbors(v0))
-    v0b: List[VT] = []
+    v0b: list[VT] = []
     for n in v0n:
         if len(list(g.edges(v0,n))) != 1:
             return None
@@ -73,10 +71,10 @@ def boundary_list_for_vertex(
 
 
 def check_pivot(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> bool:
     """Checks if an edge can be simplified using the pivot rule.
 
     :param g: An instance of a ZX-graph.
@@ -104,20 +102,20 @@ def check_pivot(
 
     maybe_v0b = boundary_list_for_vertex(g, v)
     if maybe_v0b is None: return False
-    b0: List[VT] = maybe_v0b
+    b0: list[VT] = maybe_v0b
 
     maybe_v1b = boundary_list_for_vertex(g, w)
     if maybe_v1b is None: return False
-    b1: List[VT] = maybe_v1b
+    b1: list[VT] = maybe_v1b
 
     return len(b0) + len(b1) <= 1
 
 
 def check_pivot_boundary(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> bool:
     """Checks if a boundary pivot can be applied between an interior Pauli
     vertex ``v`` and a non-Pauli Z-spider ``w`` with exactly one boundary neighbour.
 
@@ -153,10 +151,10 @@ def check_pivot_boundary(
 
 
 def check_pivot_gadget(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> bool:
     """Checks if a gadget pivot can be applied between an interior Pauli
     vertex ``v`` and an interior non-Pauli vertex ``w``.
 
@@ -192,13 +190,13 @@ def check_pivot_gadget(
 
 ## Pivot Boundary
 
-def pivot_boundary_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def pivot_boundary_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_pivot_boundary`, and if any matches are found runs :func:`pivot_NOT_REWORKED`"""
     matches = match_pivot_boundary(g)
     if len(matches) <= 0: return False
     return pivot_NOT_REWORKED(g, matches)
 
-def pivot_boundary_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def pivot_boundary_for_apply(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_pivot_boundary` on the given vertices, and if any matches are found runs :func:`pivot_NOT_REWORKED`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_pivot_boundary(g, checked_vertices)
@@ -207,13 +205,13 @@ def pivot_boundary_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
 
 ## Pivot Gadget
 
-def pivot_gadget_for_simp(g: BaseGraph[VT,ET]) -> bool:
+def pivot_gadget_for_simp(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_pivot_gadget`, and if any matches are found runs :func:`pivot_NOT_REWORKED`"""
     matches = match_pivot_gadget(g)
     if len(matches) <= 0: return False
     return pivot_NOT_REWORKED(g, matches)
 
-def pivot_gadget_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def pivot_gadget_for_apply(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_pivot_gadget` on the given vertices, and if any matches are found runs :func:`pivot_NOT_REWORKED`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_pivot_gadget(g, checked_vertices)
@@ -221,10 +219,10 @@ def pivot_gadget_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     return pivot_NOT_REWORKED(g, matches)
 
 def unsafe_pivot_boundary(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> bool:
     """Perform a boundary pivot by gadgetizing ``w`` and then pivoting on ``(v, w)``."""
     inputs = g.inputs()
 
@@ -247,10 +245,10 @@ def unsafe_pivot_boundary(
 
 
 def unsafe_pivot_gadget(
-        g: BaseGraph[VT,ET],
-        v: VT,
-        w: VT
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    v: VT,
+    w: VT
+) -> bool:
     """Perform a gadget pivot by gadgetizing ``w`` and then pivoting on ``(v, w)``.
 
     The gadget edge is created as SIMPLE because the pivot's boundary handling
@@ -269,9 +267,10 @@ def unsafe_pivot_gadget(
 
 
 def match_pivot_boundary(
-        g: BaseGraph[VT,ET],
-        vertices: Optional[List[VT]] = None,
-        num:int=-1) -> List[MatchPivotType[VT]]:
+    g: BaseGraph[VT, ET],
+    vertices: list[VT] | None = None,
+    num: int = -1
+) -> list[MatchPivotType[VT]]:
     """Like :func:`check_pivot`, but except for pairings of
     Pauli vertices, it looks for a pair of an interior Pauli vertex and a
     boundary non-Pauli Clifford vertex in order to gadgetize the non-Pauli vertex."""
@@ -281,10 +280,10 @@ def match_pivot_boundary(
     phases = g.phases()
     rs = g.rows()
 
-    edge_list: List[Tuple[VT,VT]] = []
-    consumed_vertices : Set[VT] = set()
+    edge_list: list[tuple[VT, VT]] = []
+    consumed_vertices: set[VT] = set()
     i = 0
-    m: List[MatchPivotType[VT]] = []
+    m: list[MatchPivotType[VT]] = []
     inputs = g.inputs()
     while (num == -1 or i < num) and len(candidates) > 0:
         v = candidates.pop()
@@ -307,7 +306,7 @@ def match_pivot_boundary(
             if g.is_ground(n):
                 good_vert = False
                 break
-            boundaries: List[VT] = []
+            boundaries: list[VT] = []
             wrong_match = False
             for b in g.neighbors(n):
                 if types[b] == VertexType.BOUNDARY:
@@ -343,9 +342,10 @@ def match_pivot_boundary(
     return m
 
 def match_pivot_gadget(
-        g: BaseGraph[VT,ET],
-        vertices: Optional[List[VT]] = None,
-        num:int=-1) -> List[MatchPivotType[VT]]:
+    g: BaseGraph[VT, ET],
+    vertices: list[VT] | None = None,
+    num: int = -1
+) -> list[MatchPivotType[VT]]:
     """Like :func:`check_pivot`, but except for pairings of
     Pauli vertices, it looks for a pair of an interior Pauli vertex and an
     interior non-Clifford vertex in order to gadgetize the non-Clifford vertex."""
@@ -357,9 +357,9 @@ def match_pivot_gadget(
     phases = g.phases()
     rs = g.rows()
 
-    edge_list: List[Tuple[VT,VT]] = []
+    edge_list: list[tuple[VT,VT]] = []
     i = 0
-    m: List[MatchPivotType[VT]] = []
+    m: list[MatchPivotType[VT]] = []
     while (num == -1 or i < num) and len(candidates) > 0:
         e = candidates.pop()
         v0, v1 = g.edge_st(e)
@@ -384,7 +384,7 @@ def match_pivot_gadget(
         v1n = list(g.neighbors(v1))
         if len(v1n) == 1: continue # It is a phase gadget
         bad_match = False
-        discard_edges: List[ET] = []
+        discard_edges: list[ET] = []
         for i,l in enumerate((v0n, v1n)):
             for n in l:
                 if types[n] != VertexType.Z:
@@ -416,22 +416,22 @@ def match_pivot_gadget(
     g.add_edges(edge_list,EdgeType.SIMPLE)
     return m
 
-def pivot(g: BaseGraph[VT,ET], v: VT, v1: VT) -> bool:
+def pivot(g: BaseGraph[VT, ET], v: VT, v1: VT) -> bool:
     """Checks if a pivot can be applied and then performs a pivoting rewrite"""
     if check_pivot(g, v, v1):
         return unsafe_pivot(g, v, v1)
     return False
 
-def unsafe_pivot(g: BaseGraph[VT,ET], v0: VT, v1: VT) -> bool:
+def unsafe_pivot(g: BaseGraph[VT, ET], v0: VT, v1: VT) -> bool:
     """Perform a pivoting rewrite"""
     
-    rem_verts: List[VT] = []
-    rem_edges: List[ET] = []
-    etab: Dict[Tuple[VT,VT],List[int]] = dict()
+    rem_verts: list[VT] = []
+    rem_edges: list[ET] = []
+    etab: dict[tuple[VT,VT], list[int]] = {}
 
-    b0: Optional[list[VT]] = boundary_list_for_vertex(g, v0)
+    b0 = boundary_list_for_vertex(g, v0)
     assert b0 is not None
-    b1: Optional[list[VT]] = boundary_list_for_vertex(g, v1)
+    b1 = boundary_list_for_vertex(g, v1)
     assert b1 is not None
 
     m = ((v0, v1), (b0, b1))
@@ -502,7 +502,7 @@ def unsafe_pivot(g: BaseGraph[VT,ET], v0: VT, v1: VT) -> bool:
     return True
 
 
-def pivot_NOT_REWORKED(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -> bool:
+def pivot_NOT_REWORKED(g: BaseGraph[VT, ET], matches: list[MatchPivotType[VT]]) -> bool:
     """Perform a pivoting rewrite, given a list of matches as returned by
     ``match_pivot(_gadget)``. A match is itself a list where:
 
@@ -511,9 +511,9 @@ def pivot_NOT_REWORKED(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -
     ``m[1][0]`` : list of zero or one boundaries adjacent to ``m[0]``.
     ``m[1][1]`` : list of zero or one boundaries adjacent to ``m[1]``.
     """
-    rem_verts: List[VT] = []
-    rem_edges: List[ET] = []
-    etab: Dict[Tuple[VT,VT],List[int]] = dict()
+    rem_verts: list[VT] = []
+    rem_edges: list[ET] = []
+    etab: dict[tuple[VT,VT], list[int]] = {}
 
     for m in matches:
         # compute:

--- a/pyzx/rewrite_rules/push_pauli_rule.py
+++ b/pyzx/rewrite_rules/push_pauli_rule.py
@@ -35,13 +35,11 @@ __all__ = ['check_pauli',
 
 from fractions import Fraction
 
-from typing import List, Dict, Tuple
+from ..utils import EdgeType, VertexType, FractionLike, phase_is_pauli, push_pauli_axel, vertex_is_zx, toggle_vertex, is_standard_hbox
+from ..graph.base import BaseGraph, VT, ET, upair
+from ..symbolic import Poly
 
-from pyzx.utils import EdgeType, VertexType, FractionLike, phase_is_pauli, push_pauli_axel, vertex_is_zx, toggle_vertex, is_standard_hbox
-from pyzx.graph.base import BaseGraph, VT, ET, upair
-from pyzx.symbolic import Poly
-
-def check_pauli(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
+def check_pauli(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     """Checks if a w is a Pauli and v is a spider we can push it through
     :param g: Graph to check
     :param v: Spider
@@ -72,13 +70,13 @@ def check_pauli(g: BaseGraph[VT,ET], v: VT, w: VT) -> bool:
     return False
 
 
-def pauli_push(g: BaseGraph[VT,ET], v:VT,w:VT, apply_to_boolean_axels: bool = False) -> bool:
+def pauli_push(g: BaseGraph[VT, ET], v:VT,w:VT, apply_to_boolean_axels: bool = False) -> bool:
     """Pushes a Pauli (i.e. a pi phase) through another spider."""
     if check_pauli(g, v, w): return unsafe_pauli_push(g, v, w, apply_to_boolean_axels=apply_to_boolean_axels)
     return False
 
 
-def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT, apply_to_boolean_axels: bool = False) -> bool:
+def unsafe_pauli_push(g: BaseGraph[VT, ET], v:VT, w:VT, apply_to_boolean_axels: bool = False) -> bool:
     """Pushes a Pauli (i.e. a pi phase) through another spider.
     :param g: Graph to push to
     :param v: Vertex to push through
@@ -87,9 +85,9 @@ def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT, apply_to_boolean_axels: b
         boolean Poly phase. If True, when ``v`` is a non-Pauli spider this push converts
         the boolean parameter into a non-boolean phase."""
 
-    rem_verts: List[VT] = []
-    rem_edges: List[ET] = []
-    etab: Dict[Tuple[VT,VT], List[int]] = dict()
+    rem_verts: list[VT] = []
+    rem_edges: list[ET] = []
+    etab: dict[tuple[VT,VT], list[int]] = {}
 
     # w is a Pauli and v is the spider we are going to push it through
 

--- a/pyzx/rewrite_rules/remove_id_rule.py
+++ b/pyzx/rewrite_rules/remove_id_rule.py
@@ -28,11 +28,11 @@ __all__ = ['check_remove_id',
            'remove_id',
            'unsafe_remove_id']
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import EdgeType, VertexType, get_z_box_label, vertex_is_w, get_w_io
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import EdgeType, VertexType, get_z_box_label, vertex_is_w, get_w_io
 
 
-def check_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
+def check_remove_id(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks if the given vertex can be removed."""
     if not (v in g.vertices()): return False
 
@@ -42,7 +42,7 @@ def check_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
     return check_remove_zx(g, v)
 
 
-def remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
+def remove_id(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks if the spider v can be removed and then does so"""
     if vertex_is_w(g.type(v)) and check_remove_id_w(g, v):
         return unsafe_remove_id_w(g, v)
@@ -53,7 +53,7 @@ def remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
     return False
 
 
-def unsafe_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_remove_id(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Removes the identity spider v"""
 
     if vertex_is_w(g.type(v)):
@@ -64,7 +64,7 @@ def unsafe_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:
 
 # Remove identity subrules
 
-def check_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
+def check_remove_zx(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks if the given vertex of type zx can be removed."""
     if not g.vertex_degree(v) == 2:
         return False
@@ -81,7 +81,7 @@ def check_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
         return True
     return False
 
-def unsafe_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_remove_zx(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Removes the identity spider v of type ZX. Does not handle self-loops,
     which ``check_remove_zx`` rejects (a single self-loop on a degree-2 vertex
     yields only one incident edge on some backends)."""

--- a/pyzx/rewrite_rules/self_loops_rule.py
+++ b/pyzx/rewrite_rules/self_loops_rule.py
@@ -29,10 +29,9 @@ __all__ = ['check_self_loop',
            'unsafe_remove_self_loop']
 
 
-from typing import List, Dict
 from fractions import Fraction
-from pyzx.utils import  EdgeType, vertex_is_zx_like
-from pyzx.rewrite import *
+from ..utils import EdgeType, vertex_is_zx_like
+from ..rewrite import BaseGraph, VT, ET
 
 
 def check_self_loop(g: BaseGraph[VT, ET], v: VT) -> bool:
@@ -66,8 +65,8 @@ def unsafe_remove_self_loop(g: BaseGraph[VT, ET], v: VT) -> bool:
     given vertex. Removes all self-loops of the given type
     """
 
-    etab: Dict[Tuple[VT, VT], List[int]] = dict()
-    rem_edges: List[ET] = []
+    etab: dict[tuple[VT, VT], list[int]] = {}
+    rem_edges: list[ET] = []
     ns = g.num_edges(v, v, EdgeType.SIMPLE)
     nh = g.num_edges(v, v, EdgeType.HADAMARD)
 

--- a/pyzx/rewrite_rules/supplementarity_rule.py
+++ b/pyzx/rewrite_rules/supplementarity_rule.py
@@ -25,28 +25,26 @@ __all__ = ['safe_apply_supplementarity',
            ]
 
 
-from typing import Tuple, List, Dict, Set, FrozenSet
-from typing import Optional
-from typing_extensions import Literal
-from pyzx.symbolic import Poly
-from pyzx.graph.base import BaseGraph, VT, ET
+from typing import Literal
+from ..symbolic import Poly
+from ..graph.base import BaseGraph, VT, ET
 
-MatchSupplementarityType = Tuple[VT, VT, Literal[1, 2], FrozenSet[VT]]
+MatchSupplementarityType = tuple[VT, VT, Literal[1, 2], frozenset[VT]]
 
-def simp_supplementarity(g: BaseGraph[VT,ET]) -> bool:
+def simp_supplementarity(g: BaseGraph[VT, ET]) -> bool:
     """Runs :func:`match_supplementarity` and if any matches are found runs :func:`unsafe_apply_supplementarity`"""
     matches = match_supplementarity(g)
     if len(matches) <= 0: return False
     return unsafe_apply_supplementarity(g, matches)
 
-def safe_apply_supplementarity(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
+def safe_apply_supplementarity(g: BaseGraph[VT, ET], vertices: list[VT]) -> bool:
     """Runs :func:`match_supplementarity` on the input vertices and if any matches are found runs :func:`unsafe_apply_supplementarity`"""
     checked_vertices = list([v for v in g.vertices() if (v in vertices)])
     matches = match_supplementarity(g, checked_vertices)
     if len(matches) <= 0: return False
     return unsafe_apply_supplementarity(g, matches)
 
-def match_supplementarity(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None) -> List[MatchSupplementarityType[VT]]:
+def match_supplementarity(g: BaseGraph[VT, ET], vertices: list[VT] | None = None) -> list[MatchSupplementarityType[VT]]:
     """Finds pairs of non-Clifford spiders that are connected to exactly the same set of vertices.
 
     :param g: An instance of a ZX-graph.
@@ -57,9 +55,9 @@ def match_supplementarity(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None
     else: candidates = g.vertex_set()
     phases = g.phases()
 
-    parities: Dict[FrozenSet[VT],List[VT]] = dict()
-    m: List[MatchSupplementarityType[VT]] = []
-    taken: Set[VT] = set()
+    parities: dict[frozenset[VT],list[VT]] = {}
+    m: list[MatchSupplementarityType[VT]] = []
+    taken: set[VT] = set()
     # First we find all the non-Clifford vertices and their list of neighbors
     while len(candidates) > 0:
         v = candidates.pop()
@@ -91,11 +89,11 @@ def match_supplementarity(g: BaseGraph[VT,ET], vertices: Optional[List[VT]]=None
     return m
 
 def unsafe_apply_supplementarity(
-        g: BaseGraph[VT,ET],
-        matches: List[MatchSupplementarityType[VT]]
-        ) -> bool:
+    g: BaseGraph[VT, ET],
+    matches: list[MatchSupplementarityType[VT]]
+) -> bool:
     """Given the output of :func:``match_supplementarity``, removes non-Clifford spiders that act on the same set of targets through supplementarity."""
-    rem: List[VT] = []
+    rem: list[VT] = []
     for v, w, t, neigh in matches:
         rem.append(v)
         rem.append(w)
@@ -124,5 +122,3 @@ def unsafe_apply_supplementarity(
     g.remove_isolated_vertices()
 
     return True
-
-

--- a/pyzx/rewrite_rules/unfuse_FE_rules.py
+++ b/pyzx/rewrite_rules/unfuse_FE_rules.py
@@ -71,7 +71,7 @@ from pyzx.graph.base import BaseGraph, VT, ET
 from pyzx.utils import VertexType, EdgeType, is_pauli
 
 
-def _linear_sum_assignment_itertools(cost_matrix) -> tuple[list, list]:
+def _linear_sum_assignment_itertools(cost_matrix: list[list[float]]) -> tuple[list[int], list[int]]:
     rows = list(range(len(cost_matrix)))
     cols = list(range(len(cost_matrix[0]) if cost_matrix else 0))
 
@@ -235,7 +235,7 @@ def unsafe_unfuse_5_FE(g: BaseGraph[VT, ET], v: VT) -> bool:
     return _unsafe_unfuse_spider(g, v, lambda x, y: _get_n_cycle_coords(5, x, y))
 
 def check_unfuse_n_2FE(g: BaseGraph[VT, ET], v: VT) -> bool:
-    return g.type(v) in (VertexType.X, VertexType.Z) and g.phase(v) == 0 
+    return g.type(v) in (VertexType.X, VertexType.Z) and g.phase(v) == 0
 
 def unfuse_n_2FE(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Unfuses a degree-n spider into a n-sided polygon"""

--- a/pyzx/rewrite_rules/unfuse_FE_rules.py
+++ b/pyzx/rewrite_rules/unfuse_FE_rules.py
@@ -65,10 +65,10 @@ __all__ = [
 
 import itertools
 import math
-from typing import Callable, Optional, List
+from collections.abc import Callable
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import VertexType, EdgeType, is_pauli
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import VertexType
 
 
 def _linear_sum_assignment_itertools(cost_matrix: list[list[float]]) -> tuple[list[int], list[int]]:
@@ -90,9 +90,9 @@ def _linear_sum_assignment_itertools(cost_matrix: list[list[float]]) -> tuple[li
 
 
 def _find_best_pairing(
-        g: BaseGraph[VT, ET],
-        neighbors: list[VT],
-        new_vertices: list[VT]
+    g: BaseGraph[VT, ET],
+    neighbors: list[VT],
+    new_vertices: list[VT]
 ) -> tuple:
     """Finds the optimal assignment using the Hungarian algorithm if available,
     otherwise falls back to lighter solvers / heuristics."""
@@ -116,9 +116,9 @@ def _find_best_pairing(
 
 
 def _find_best_assignment(
-        g: BaseGraph[VT, ET],
-        items_to_assign: list[VT],
-        available_slots: list[VT]
+    g: BaseGraph[VT, ET],
+    items_to_assign: list[VT],
+    available_slots: list[VT]
 ) -> dict[VT, VT]:
     """
     Finds the optimal assignment of items to slots (where len(slots) >= len(items))
@@ -171,9 +171,9 @@ def _get_n_cycle_coords(N: int, q: float, r: float) -> list[tuple[float, float]]
 
 
 def _unsafe_unfuse_spider(
-        g: BaseGraph[VT, ET],
-        v: VT,
-        coords_func: Callable
+    g: BaseGraph[VT, ET],
+    v: VT,
+    coords_func: Callable
 ) -> bool:
     """A generic function to unfuse a spider into a polygon of new spiders."""
     v_type = g.type(v)
@@ -270,9 +270,9 @@ def _split_neighbors_into_groups(g: BaseGraph[VT, ET], neighbors: list[VT]) -> t
 
 
 def _calculate_new_spider_positions(
-        g: BaseGraph[VT, ET],
-        group1: list[VT],
-        group2: list[VT]
+    g: BaseGraph[VT, ET],
+    group1: list[VT],
+    group2: list[VT]
 ) -> tuple[float, float, float]:
     """Calculates the average positions for the two new central spiders based on the groups."""
     all_neighbors = group1 + group2
@@ -285,8 +285,7 @@ def _calculate_new_spider_positions(
     return pos_q1, pos_q2, start_from
 
 
-def _unfuse_2n_spider_core(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> tuple[
-    VT, VT]:
+def _unfuse_2n_spider_core(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> tuple[VT, VT]:
     """
     The core function that performs the 2n-degree unfusing operation.
 
@@ -329,7 +328,7 @@ def _unfuse_2n_spider_core(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None)
     return inner_1, inner_2
 
 
-def unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Unfuses a degree-2n spider into two degree-n spiders.
 
@@ -342,7 +341,7 @@ def unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
     return unsafe_unfuse_2n_FE(g, v, w)
 
 
-def unsafe_unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def unsafe_unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Unfuses a degree-2n spider into two degree-n spiders.
 
@@ -354,7 +353,7 @@ def unsafe_unfuse_2n_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) ->
     return True
 
 
-def unfuse_2n_plus_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def unfuse_2n_plus_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Unfuses a degree-(2n + 1) spider into a degree-n spider and a degree-(n + 1) spider.
 
@@ -367,7 +366,7 @@ def unfuse_2n_plus_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> b
     return unsafe_unfuse_2n_plus_FE(g, v, w)
 
 
-def unsafe_unfuse_2n_plus_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def unsafe_unfuse_2n_plus_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Unfuses a degree-(2n + 1) spider into a degree-n spider and a degree-(n + 1) spider.
 
@@ -383,7 +382,7 @@ def check_recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT) -> bool:
     return g.type(v) in (VertexType.X, VertexType.Z) and g.phase(v) == 0
 
 
-def recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Recursively unfuses a spider.
 
@@ -396,7 +395,7 @@ def recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) ->
     return unsafe_recursive_unfuse_FE(g, v, w)
 
 
-def unsafe_recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT, w: Optional[int] = None) -> bool:
+def unsafe_recursive_unfuse_FE(g: BaseGraph[VT, ET], v: VT, w: int | None = None) -> bool:
     """
     Recursively unfuses a spider.
 

--- a/pyzx/rewrite_rules/z_to_z_box_rule.py
+++ b/pyzx/rewrite_rules/z_to_z_box_rule.py
@@ -30,17 +30,16 @@ __all__ = [
         'unsafe_z_to_z_box',]
 
 
-from typing import List, Callable, Optional
 import numpy as np
 
-from pyzx.symbolic import Poly
+from ..symbolic import Poly
 
-from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.utils import VertexType, set_z_box_label
+from ..graph.base import BaseGraph, VT, ET
+from ..utils import VertexType, set_z_box_label
 
 
 def check_z_to_z_box(
-        g: BaseGraph[VT,ET],
+        g: BaseGraph[VT, ET],
         v: VT ) -> bool:
     """checks if a given vertex can be converted to Z-boxes."""
 
@@ -51,13 +50,13 @@ def check_z_to_z_box(
         return True
     return False
 
-def z_to_z_box(g: BaseGraph[VT,ET], v: VT) -> bool:
+def z_to_z_box(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks and converts a Z vertex to a Z-box."""
     if check_z_to_z_box(g, v):
         return unsafe_z_to_z_box(g, v)
     return False
 
-def unsafe_z_to_z_box(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_z_to_z_box(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Converts a Z vertex to a Z-box."""
 
     g.set_type(v, VertexType.Z_BOX)

--- a/pyzx/rewrite_rules/zero_hbox_rule.py
+++ b/pyzx/rewrite_rules/zero_hbox_rule.py
@@ -28,11 +28,11 @@ __all__ = ['check_zero_hbox',
 
 
 import cmath
-from pyzx.utils import VertexType, get_h_box_label, hbox_has_complex_label
-from pyzx.graph.base import BaseGraph, ET, VT
+from ..utils import VertexType, get_h_box_label, hbox_has_complex_label
+from ..graph.base import BaseGraph, ET, VT
 
 
-def check_zero_hbox(g: BaseGraph[VT,ET], v:VT) -> bool:
+def check_zero_hbox(g: BaseGraph[VT, ET], v:VT) -> bool:
     """Matches H-boxes with label 1 (or phase 0)."""
     types = g.types()
     if types[v] != VertexType.H_BOX:
@@ -42,12 +42,12 @@ def check_zero_hbox(g: BaseGraph[VT,ET], v:VT) -> bool:
     return g.phase(v) == 0
 
 
-def zero_hbox(g: BaseGraph[VT,ET], v: VT) -> bool:
+def zero_hbox(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Checks if the given vertex can be removed, then removes H-boxes with a phase of 2pi=0."""
     if check_zero_hbox(g, v): return unsafe_zero_hbox(g, v)
     return False
 
-def unsafe_zero_hbox(g: BaseGraph[VT,ET], v: VT) -> bool:
+def unsafe_zero_hbox(g: BaseGraph[VT, ET], v: VT) -> bool:
     """Removes H-boxes with a phase of 2pi=0.
     Note that this rule is only semantically correct when all its neighbors are white spiders."""
     g.remove_vertex(v)


### PR DESCRIPTION
Type annotations for another module, with the usual cleanup to conform to PEP8 recommendations for 3.10 syntax. Imports were also standardised to be relative, since that's what the majority of the codebase does. 

Two concerns:
- It might be a good time to remove `rules.py` and `hrules.py`, since they're just entirely comments of the old code before the refactor last year. I just left them completely untouched for now.
- `gadget_phasepoly_rule.py` has several `#type: ignore` comments which seem like they may be hiding actual runtime exceptions based on my cursory look at them. I didn't actually run the code to test so I left them be for now, but perhaps it's worth taking a closer look. If they're correct, then ideally we'd rewrite the code so the type-checker can actually verify it.